### PR TITLE
Found that multi-player forest spline header

### DIFF
--- a/HeroesPowerPlant/ConfigEditor/EXEExtractor.cs
+++ b/HeroesPowerPlant/ConfigEditor/EXEExtractor.cs
@@ -42,6 +42,7 @@ namespace HeroesPowerPlant.ConfigEditor
                 { Stage.MadExpress, 0x16973D },
                 { Stage.TerrorHall, 0x1785D3 },
                 { Stage.RailCanyonExpert, 0x16983D },
+                { Stage.FrogForestExpert,0x169998 },
                 { Stage.EggFleetExpert, 0x178473 }
             };
 


### PR DESCRIPTION
Spline headers are parametized for 0x439020, but have finally found the missing header through debugging the audio set function.