### PR TITLE
Shadow Misc Bytes (Round 2: Lots of Objs)

### DIFF
--- a/HeroesPowerPlant/LayoutEditor/LayoutEditorFunctions.cs
+++ b/HeroesPowerPlant/LayoutEditor/LayoutEditorFunctions.cs
@@ -820,14 +820,36 @@ namespace HeroesPowerPlant.LayoutEditor
                     {
                         case 0x01: case 0x02: case 0x03: case 0x06: return new Object00_SpringShadow();
                         case 0x04: return new Object0004_DashRamp();
+                        case 0x05: return new Object0005_Checkpoint();
                         case 0x07: return new Object0007_Case();
+                        case 0x08: return new Object0008_Pulley();
+                        case 0x09: return new Object0009_WoodBox();
+                        case 0x0A: return new Object000A_MetalBox();
+                        case 0x0B: return new Object000B_UnbreakableBox();
+                        case 0x0C: return new Object000C_WeaponBox();
                         case 0x0E: return new Object000E_Rocket();
                         case 0x0F: return new Object000F_Platform();
                         case 0x10: return new Object0010_Ring();
+                        case 0x11: return new Object0011_HintBall();
                         case 0x12: return new Object0012_ItemCapsule();
+                        case 0x13: return new Object0013_Balloon();
                         case 0x14: return new Object0014_GoalRing();
+                        case 0x15: return new Object0015_BallSwitch();
+                        case 0x16: return new Object0016_TargetSwitch();
+                        case 0x19: return new Object0019_Weight();
+                        case 0x1A: return new Object001A_Wind();
+                        case 0x1B: return new Object001B_Roadblock();
                         case 0x20: return new Object0020_Weapon();
+                        case 0x23: return new Object0023_OverturnableObject();
+                        case 0x3A: return new Object003A_SpecialWeaponBox();
+                        case 0x33: return new Object0033_EnergyCore();
+                        case 0x34: return new Object0034_Fire();
+                        case 0x35: return new Object0034_Fire(); //PoisonGas
                         case 0x4F: return new Object004F_Vehicle();
+                        case 0x50: return new Object0050_Trigger();
+                        case 0x51: return new Object0051_TriggerTalking();
+                        case 0x5A: return new Object005A_Pole();
+                        case 0x62: return new Object0062_LightColli();
                         case 0x64: return new Object0064_GUNSoldier();
                         case 0x65: return new Object0065_GUNBeetle();
                         case 0x66: return new Object0066_GUNBigfoot();
@@ -848,12 +870,35 @@ namespace HeroesPowerPlant.LayoutEditor
                 case 0x01:
                     switch (Type)
                     {
+                        case 0x2C: return new Object012C_EnvironmentalWeapon();
                         case 0x90: return new Object0190_Partner();
+                        default: return new Object_ShadowDefault();
+                    }
+                case 0x03:
+                    switch (Type) {
+                        case 0xE9: return new Object03E9_FallingBuilding();
+                        case 0xEA: return new Object03EA_GiantSkyLaser();
                         default: return new Object_ShadowDefault();
                     }
                 case 0x07:
                     switch (Type) {
+                        case 0xD1: return new Object07D1_Searchlight();
+                        case 0xD2: return new Object07D2_ColorSwitch();
+                        case 0xD3: return new Object07D3_RisingLaserBar();
                         case 0xD4: return new Object07D4_ElecSecurity();
+                        case 0xD5: return new Object07D5_LightspeedRisingBlock();
+                        case 0xD7: return new Object07D7_DigitalBreakableTile();
+                        case 0xDE: return new Object00_SpringShadow();
+                        case 0xDF: return new Object07DF_LightspeedFirewall();
+                        case 0xE1: return new Object07E1_TriggerDigitalBreakableTile();
+                        case 0xEB: return new Object07EB_CubePlatformCircle();
+                        default: return new Object_ShadowDefault();
+                    }
+                case 0x08:
+                    switch (Type) {
+                        case 0x34: return new Object0834_TornadoObject1();
+                        case 0x35: return new Object0835_TornadoObject2();
+                        case 0x36: return new Object0836_TornadoObject3();
                         default: return new Object_ShadowDefault();
                     }
                 case 0x0B:
@@ -862,16 +907,43 @@ namespace HeroesPowerPlant.LayoutEditor
                         case 0xBE: return new Object0BBE_Chao();
                         default: return new Object_ShadowDefault();
                     }
+                case 0x10:
+                    switch (Type) {
+                        case 0x69: return new Object1069_FleetHolderEggmanBattleship();
+                        default: return new Object_ShadowDefault();
+                    }
                 case 0x11:
                     switch (Type)
                     {
                         case 0x31: return new Object1131_Vine();
                         default: return new Object_ShadowDefault();
                     }
+                case 0x13:
+                    switch (Type)
+                    {
+                        case 0x92: return new Object1392_SpaceDebris();
+                        default: return new Object_ShadowDefault();
+                    }
+                case 0x17:
+                    switch (Type)
+                    {
+                        case 0x72: return new Object1772_ConcreteDoor();
+                        case 0x73: return new Object1773_CrushingWalls();
+                        case 0xD4: return new Object11D4_BAGunShip();
+                        case 0xD5: return new Object17D5_BlackArmsMine();
+                        default: return new Object_ShadowDefault();
+                    }
                 case 0x18:
                     switch (Type)
                     {
+                        case 0x39: return new Object1839_RisingLava();
                         case 0x9E: return new Object189E_ARKDriftingPlat1();
+                        default: return new Object_ShadowDefault();
+                    }
+                case 0x19:
+                    switch (Type) {
+                        case 0x01: return new Object1901_CometBarrier();
+                        case 0x03: return new Object1903_BlackDoomHologram();
                         default: return new Object_ShadowDefault();
                     }
                 case 0x25:
@@ -879,7 +951,14 @@ namespace HeroesPowerPlant.LayoutEditor
                     {
                         case 0x88: return new Object2588_Decoration1();
                         case 0x89: return new Object2589_Destructable1();
+                        case 0x8A: return new Object258A_Effect1();
                         case 0x90: return new Object2588_Decoration1();
+                        case 0x91: return new Object2589_Destructable1();
+                        case 0x93: return new Object2593_SetGenerator();
+                        case 0x94: return new Object2594_Fan();
+                        case 0x95: return new Object2595_MissionClearCollision();
+                        case 0x97: return new Object2597_SetSeLoop();
+                        case 0x98: return new Object2598_SetSeOneShot();
                         default: return new Object_ShadowDefault();
                     }
                 default: return new Object_ShadowDefault();

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/ItemShadow.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/ItemShadow.cs
@@ -2,6 +2,7 @@
 {
     public enum ItemShadow
     {
+        NotValidInObject = -1,
         Rings5 = 0,
         Rings10 = 1,
         Rings20 = 2,

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0005_Checkpoint.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0005_Checkpoint.cs
@@ -1,0 +1,8 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0005_Checkpoint : SetObjectShadow {
+        public int Number {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0007_Case.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0007_Case.cs
@@ -2,12 +2,10 @@
 {
     public class Object0007_Case : SetObjectShadow
     {
-        public string Note => "Not all misc. settings are in list yet.";
-
-        public int CaseType
+        public LockedCaseType CaseType
         {
-            get => ReadInt(0);
-            set => Write(0, value);
+            get => (LockedCaseType)ReadInt(0);
+            set => Write(0, (int)value);
         }
 
         public float ScaleX
@@ -27,6 +25,11 @@
             get => ReadFloat(12);
             set => Write(12, value);
         }
+    }
+
+    public enum LockedCaseType {
+        BlackArms,
+        GUN
     }
 }
 

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0008_Pulley.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0008_Pulley.cs
@@ -1,0 +1,26 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0008_Pulley : SetObjectShadow {
+        
+        // Real name UpDownReel / UD_REEL::length,angle,power
+
+        public float StartingLength {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+        public float EndingLength {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+
+        public float LetGoAngle {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+
+        public float LetGoLaunchForce {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0009_WoodBox.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0009_WoodBox.cs
@@ -1,0 +1,39 @@
+﻿using System.ComponentModel;
+
+namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0009_WoodBox : SetObjectShadow {
+        public BoxType BoxType {
+            get => (BoxType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public BoxItem ItemType {
+            get => (BoxItem)ReadInt(4);
+            set => Write(4, (int)value);
+        }
+
+        [Description("Use this if ItemType is any other type")]
+        public int ItemTypeModifier {
+            get => ReadInt(8);
+            set => Write(8, value);
+        }
+
+        [Description("Use this if ItemType is ItemCapsule")]
+        public ItemShadow ModifierCapsule {
+            get => (ItemShadow)ReadInt(8);
+            set => Write(8, (int)value);
+        }
+
+        [Description("Use this if ItemType is Weapon")]
+        public Weapon ModifierWeapon {
+            get => (Weapon)ReadInt(8);
+            set => Write(8, (int)value);
+        }
+
+        [Description("Use this if ItemType is EnergyCore")]
+        public EnergyCoreType ModifierEnergyCore {
+            get => (EnergyCoreType)ReadInt(8);
+            set => Write(8, (int)value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object000A_MetalBox.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object000A_MetalBox.cs
@@ -1,0 +1,81 @@
+﻿using System.ComponentModel;
+
+namespace HeroesPowerPlant.LayoutEditor {
+    public class Object000A_MetalBox : SetObjectShadow {
+        public BoxType BoxType {
+            get => (BoxType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public string Warning => "If you see \"NotValidInObject\" or -1, Do not edit field.";
+
+        public BoxItem ItemType {
+            get {
+                if (MiscSettings.Length > 4)
+                    return (BoxItem)ReadInt(4);
+                return (BoxItem)(-1);
+            }
+            set {
+                if (MiscSettings.Length < 8)
+                    return;
+                Write(4, (int)value);
+            }
+        }
+
+        [Description("Use this if ItemType is any other type")]
+        public int ItemTypeModifier {
+            get {
+                if (MiscSettings.Length > 8)
+                    return ReadInt(8);
+                return -1;
+            }
+            set {
+                if (MiscSettings.Length < 12)
+                    return;
+                Write(8, value);
+            }
+        }
+
+        [Description("Use this if ItemType is ItemCapsule")]
+        public ItemShadow ModifierCapsule {
+            get {
+                if (MiscSettings.Length > 8)
+                    return (ItemShadow)ReadInt(8);
+                return (ItemShadow)(-1);
+            }
+            set {
+                if (MiscSettings.Length < 12)
+                    return;
+                Write(8, (int)value);
+            }
+        }
+
+        [Description("Use this if ItemType is Weapon")]
+        public Weapon ModifierWeapon {
+            get {
+                if (MiscSettings.Length > 8)
+                    return (Weapon)ReadInt(8);
+                return (Weapon)(-1);
+            }
+            set {
+                if (MiscSettings.Length < 12)
+                    return;
+                Write(8, (int)value);
+            }
+        }
+
+        [Description("Use this if ItemType is EnergyCore")]
+        public EnergyCoreType ModifierEnergyCore {
+            get {
+                if (MiscSettings.Length > 8)
+                    return (EnergyCoreType)ReadInt(8);
+                return (EnergyCoreType)(-1);
+            }
+            set {
+                if (MiscSettings.Length < 12)
+                    return;
+                Write(8, (int)value);
+            }
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object000B_UnbreakableBox.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object000B_UnbreakableBox.cs
@@ -1,0 +1,8 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object000B_UnbreakableBox : SetObjectShadow {
+        public BoxType BoxType {
+            get => (BoxType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object000C_WeaponBox.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object000C_WeaponBox.cs
@@ -1,0 +1,13 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object000C_WeaponBox : SetObjectShadow {
+        public BoxType BoxType {
+            get => (BoxType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public Weapon Weapon {
+            get => (Weapon)ReadInt(4);
+            set => Write(4, (int)value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object000F_Platform.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object000F_Platform.cs
@@ -2,16 +2,20 @@
 {
     public class Object000F_Platform : SetObjectShadow
     {
-        public int PlatformType
+        // Needs further research
+        // ElecBlock
+        // Enums: BlockType 0-9 (unused?); CollisionFlag<FALSE/TRUE>
+        // ElecBlock(BlockType, SearchRange, InitialY, CollisionFlag)
+        public PlatformBlockType PlatformType
         {
-            get => ReadInt(0);
-            set => Write(0, value);
+            get => (PlatformBlockType)ReadInt(0);
+            set => Write(0, (int)value);
         }
 
-        public int Unknown_04
+        public PlatformMoveType MovementType
         {
-            get => ReadInt(4);
-            set => Write(4, value);
+            get => (PlatformMoveType)ReadInt(4);
+            set => Write(4, (int)value);
         }
 
         public float TravelTime
@@ -26,15 +30,15 @@
             set => Write(12, value);
         }
 
-        public int Unknown_10
+        public float float_10
         {
-            get => ReadInt(0x10);
+            get => ReadFloat(0x10);
             set => Write(0x10, value);
         }
 
-        public int Unknown_14
+        public float float_14
         {
-            get => ReadInt(0x14);
+            get => ReadFloat(0x14);
             set => Write(0x14, value);
         }
 
@@ -56,10 +60,25 @@
             set => Write(0x20, value);
         }
 
-        public int Unknown_24
+        public float float_24
         {
-            get => ReadInt(0x24);
+            get => ReadFloat(0x24);
             set => Write(0x24, value);
         }
+    }
+
+    public enum PlatformBlockType {
+        Type0,
+        Type1,
+        Type2,
+        Type3
+    }
+
+    public enum PlatformMoveType {
+        Linear=0,
+        Unknown2=2,
+        TranslationOnLinkID=3,
+        Lerp=4,
+        Slerp=6
     }
 }

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0011_HintBall.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0011_HintBall.cs
@@ -1,0 +1,30 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0011_HintBall : SetObjectShadow {
+        //AKA SetHintRing
+
+        public int AudioBranchID {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+
+        public AudioBranchType AudioBranchType {
+            get => (AudioBranchType)ReadInt(4);
+            set => Write(4, (int)value);
+        }
+
+        public float Float_02 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+
+        public float Float_03 {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public int Int_04 {
+            get => ReadInt(16);
+            set => Write(16, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0013_Balloon.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0013_Balloon.cs
@@ -1,0 +1,44 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0013_Balloon : SetObjectShadow {
+        public BalloonType BalloonType  {
+            get => (BalloonType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public ItemShadow ItemType {
+            get => (ItemShadow)ReadInt(4);
+            set => Write(4, (int)value);
+        }
+
+        public float SpeedDampAmount {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+
+        public float OrbitDistance {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public float TranslationX {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+
+        public float TranslationY {
+            get => ReadFloat(20);
+            set => Write(20, value);
+        }
+
+        public float TranslationZ {
+            get => ReadFloat(24);
+            set => Write(24, value);
+        }
+    }
+
+    public enum BalloonType {
+        TranslationOnceAndDisappear,
+        TranslationLoop,
+        Orbit
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0015_BallSwitch.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0015_BallSwitch.cs
@@ -1,0 +1,18 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0015_BallSwitch : SetObjectShadow {
+        // Switch
+
+        public BallSwitchActivateType ActivateType {
+            get => (BallSwitchActivateType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+    }
+
+    public enum BallSwitchActivateType {
+        OnOff=0,
+        OnTouch=1,
+        OnAlways=2,
+        Decoration=3
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0016_TargetSwitch.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0016_TargetSwitch.cs
@@ -1,0 +1,34 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0016_TargetSwitch : SetObjectShadow {
+
+        public float Move_X {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+
+        public float Move_Y {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+
+        public float Move_Z {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+
+        public float MoveSpeed {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public float MoveWait {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+
+        public int NumberOfHits {
+            get => ReadInt(20);
+            set => Write(20, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0019_Weight.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0019_Weight.cs
@@ -1,0 +1,62 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0019_Weight : SetObjectShadow {
+
+        public WeightMoveType MoveType {
+            get => (WeightMoveType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public float Height {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+
+        public float WaitTimeTop {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+
+        public float WaitTimeBottom {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public float WaitTimeIfShot {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+
+        //UNKNOWN 5 ALWAYS 0
+        public int u5_int { //1 = never rise again
+            get => ReadInt(20);
+            set => Write(20, value);
+        }
+
+        public float u5_float {
+            get => ReadFloat(20);
+            set => Write(20, value);
+        }
+
+        public float ScaleX {
+            get => ReadFloat(24);
+            set => Write(24, value);
+        }
+
+        public float ScaleY {
+            get => ReadFloat(28);
+            set => Write(28, value);
+        }
+
+        public float ScaleZ {
+            get => ReadFloat(32);
+            set => Write(32, value);
+        }
+    }
+
+    public enum WeightMoveType {
+        UpDown,
+        WaitForPlayer,
+        NeverMove
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object001A_Wind.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object001A_Wind.cs
@@ -1,14 +1,15 @@
 ﻿using System.ComponentModel;
 
 namespace HeroesPowerPlant.LayoutEditor {
-    public class Object2594_Fan : SetObjectShadow {
+    public class Object001A_Wind : SetObjectShadow {
+        // Technically a copy of "Fan", with a unique model
 
-        public FanType FanType { //0 or 1
+        public FanType DirectionType { //0 or 1
             get => (FanType)ReadInt(0);
             set => Write(0, (int)value);
         }
 
-        public FanForm FanForm { //0
+        public FanForm BlowerType { //0 or 1
             get => (FanForm)ReadInt(4);
             set => Write(4, (int)value);
         }
@@ -18,7 +19,7 @@ namespace HeroesPowerPlant.LayoutEditor {
             set => Write(8, value);
         }
 
-        [Description("Only for FanForm BoxType")]
+        [Description("Only for BlowerType BoxType")]
         public float BoxTypeAirHeight { //always 0
             get => ReadFloat(12);
             set => Write(12, value);
@@ -49,32 +50,16 @@ namespace HeroesPowerPlant.LayoutEditor {
             get => (CommonNoYes)ReadInt(32);
             set => Write(32, (int)value);
         }
-
-        public FanRunning FanRunning { //-1 or 255
+        public FanRunning WindBlowing { //-1 or 255
             get => (FanRunning)ReadInt(36);
             set => Write(36, (int)value);
         }
 
-        [Description("FanRunning shares this, can set to LinkID to watch for")]
+        [Description("WindBlowing shares this, can set to LinkID to watch for")]
         public int LinkIDMakeRun {
             get => ReadInt(36);
             set => Write(36, value);
         }
-    }
-
-    public enum FanType {
-        UpperWay,
-        SideWay
-    }
-
-    public enum FanForm {
-        Cylinder,
-        Box,
-    }
-
-    public enum FanRunning {
-        Yes=-1,
-        No=255
     }
 }
 

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object001B_Roadblock.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object001B_Roadblock.cs
@@ -1,0 +1,15 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object001B_Roadblock : SetObjectShadow {
+        //BreakObj
+        public RoadblockType RoadblockType {
+            get => (RoadblockType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+    }
+
+    public enum RoadblockType {
+        GUN,
+        BlackArms
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0020_Weapon.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0020_Weapon.cs
@@ -11,6 +11,7 @@
 
     public enum Weapon
     {
+        NotValidInObject = -1,
         None = 0x00,
         Pistol = 0x01,
         SubmachineGun = 0x02,
@@ -32,15 +33,15 @@
         RPG = 0x12,
         FourShot = 0x13,
         EightShot = 0x14,
-        WormShooteBlack = 0x15,
+        WormShooterBlack = 0x15,
         WideWormShooterRed = 0x16,
         BigWormShooterGold = 0x17,
         VacuumPod = 0x18,
         LaserRifle = 0x19,
         Splitter = 0x1A,
         Refractor = 0x1B,
-        None1C = 0x1C,
-        None1D = 0x1D,
+        UnusedGUNWeaponSlot = 0x1C,
+        UnusedBlackArmsWeaponSlot = 0x1D,
         Knife = 0x1E,
         BlackSword = 0x1F,
         DarkHammer = 0x20,

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0023_OverturnableObject.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0023_OverturnableObject.cs
@@ -1,0 +1,12 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0023_OverturnableObject : SetObjectShadow {
+        public int ModelIfMultiple {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+        public int UnusedInt {
+            get => ReadInt(4);
+            set => Write(4, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0033_EnergyCore.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0033_EnergyCore.cs
@@ -1,0 +1,9 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0033_EnergyCore : SetObjectShadow {
+        public EnergyCoreType CoreType {
+            get => (EnergyCoreType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0034_Fire.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0034_Fire.cs
@@ -1,0 +1,25 @@
+﻿using System.ComponentModel;
+
+namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0034_Fire : SetObjectShadow {
+        // Fire(ScaleX, ScaleY, ScaleZ)
+        // Probably late in development changed to hardcoded fire scale
+        // OR oversight and forgot to read from params
+        // Still documenting this as some objects have misc bytes, even if unused
+        // In the future a Gecko code might re-enable the object to read these.
+
+        [Description("These fields are unused. A gecko code may make them usable.")]
+        public float Fire_ScaleX {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+        public float Fire_ScaleY {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float Fire_ScaleZ {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object003A_SpecialWeaponBox.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object003A_SpecialWeaponBox.cs
@@ -1,0 +1,9 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object003A_SpecialWeaponBox : SetObjectShadow {
+        public Weapon WeaponIfSpecialWeaponsNotUnlocked {
+            get => (Weapon)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0050_Trigger.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0050_Trigger.cs
@@ -1,0 +1,80 @@
+﻿using System.ComponentModel;
+
+namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0050_Trigger : SetObjectShadow {
+
+        //SetCollision
+
+        public TriggerType Type {
+            get => (TriggerType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public TriggerShape Shape {
+            get => (TriggerShape)ReadInt(4);
+            set => Write(4, (int)value);
+        }
+
+        public float Size_X {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+
+        public float Size_Y {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public float Size_Z {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+
+        [Description("LinkIDTrigger's LinkID to Activate OR LinkID to watch in other types")]
+        //Disappear
+        public int Affect_LinkID { //5
+            get => ReadInt(20);
+            set => Write(20, value);
+        }
+
+        // 6 Does not appear on 2 objects throughout the game
+        [Description("Set Disappear/Appear behavior when LinkID condition met.")]
+        public TriggerLinkBehavior TriggerLinkBehavior { //6
+            get {
+                if (MiscSettings.Length > 24)
+                    return (TriggerLinkBehavior)ReadInt(24);
+                return (TriggerLinkBehavior)(-1);
+            }
+            set {
+                if (MiscSettings.Length < 28)
+                    return;
+                Write(24, (int)value);
+            }
+        }
+    }
+
+    public enum TriggerType {
+        SolidCollision=0,
+        LinkIDTrigger=2,
+        HurtPlayer=3,
+        KillPlayer=4,
+        ChaosControlCancelOn=5,
+        ChaosControlCancelOff=6,
+        ChaosControlStop=7,
+        MaintainBehaviorSkydive=9,
+        LockControlsWhileInTrigger=10,
+        CompleteMission=11
+    }
+
+    public enum TriggerShape {
+        Cylinder,
+        Cube,
+        Cone
+    }
+
+    public enum TriggerLinkBehavior {
+        NotValidInObject = -1,
+        Disappear = 0,
+        Appear = 1
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0051_TriggerTalking.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0051_TriggerTalking.cs
@@ -1,0 +1,101 @@
+﻿using System.ComponentModel;
+
+namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0051_TriggerTalking : SetObjectShadow {
+        //AKA SetHintCollision
+
+        public TriggerShape Shape {
+            get => (TriggerShape)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public float Size_X {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+
+        public float Size_Y {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+
+        public float Size_Z {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public int AudioBranchID {
+            get => ReadInt(16);
+            set => Write(16, value);
+        }
+
+        public AudioBranchType AudioBranchType {
+            get => (AudioBranchType)ReadInt(20);
+            set => Write(20, (int)value);
+        }
+
+        public float float_06 {
+            get => ReadFloat(24);
+            set => Write(24, value);
+        }
+
+        public int int_07 {
+            get => ReadInt(28);
+            set => Write(28, value);
+        }
+
+        public float float_07 {
+            get => ReadFloat(28);
+            set => Write(28, value);
+        }
+
+        public int int_08 { //8 int | 0, 7 [can be null]
+            get {
+                if (MiscSettings.Length > 32)
+                    return ReadInt(32);
+                return -1;
+            }
+            set {
+                if (MiscSettings.Length < 36)
+                    return;
+                Write(32, value);
+            }
+        }
+
+        // 6 Does not appear on 2 objects throughout the game
+        [Description("Set Disappear/Appear behavior when LinkID condition met.")]
+        public TriggerLinkBehavior TriggerLinkBehavior {
+            get {
+                if (MiscSettings.Length > 36)
+                    return (TriggerLinkBehavior)ReadInt(36);
+                return (TriggerLinkBehavior)(-1);
+            }
+            set {
+                if (MiscSettings.Length < 40)
+                    return;
+                Write(36, (int)value);
+            }
+        }
+
+        [Description("Same slot as TriggerLinkBehavior, but one object may have this field as a float")]
+        //9 int OR float // 0, 1 | float 140 | [can be null]
+        public float float_09 {
+            get {
+                if (MiscSettings.Length > 36)
+                    return ReadFloat(36);
+                return -1;
+            }
+            set {
+                if (MiscSettings.Length < 40)
+                    return;
+                Write(36, value);
+            }
+        }
+    }
+    public enum AudioBranchType {
+        CurrentMissionPartner=-1,
+        Dark=0,
+        Normal=1,
+        Hero=2
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0059_TriggerSkybox.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0059_TriggerSkybox.cs
@@ -1,0 +1,33 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0059_TriggerSkybox : SetObjectShadow {
+
+        // 0 unk (always 0)
+        // 1 int
+        // 2 float
+        // 3 int
+        // 4 int
+        // 5 int
+        // 6 int
+
+        public LockedCaseType CaseType {
+            get => (LockedCaseType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public float ScaleX {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+
+        public float ScaleY {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+
+        public float ScaleZ {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object005A_Pole.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object005A_Pole.cs
@@ -1,0 +1,8 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object005A_Pole : SetObjectShadow {
+        public float float0 {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0062_LightColli.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List00/Object0062_LightColli.cs
@@ -1,0 +1,93 @@
+﻿using System.ComponentModel;
+
+namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0062_LightColli : SetObjectShadow {
+        //LightColli [LightColliMasterTask parent]
+        //Enums:
+        // SWITCH_ON, SWITCH_OFF
+        // CYLINDER
+        // LightNo:PLAYER_0-3; OBJECT_0-3; ENEMY_0-3, KAGE, OTHER_0-2, DoNotUse
+        // Light OFF, Light ON
+        // Effect OFF, Effect ON
+        // Params:
+        // LightColli(LightFlag, LightNumber, EffectFlag, EffectNumber)
+        public LightColli_SwitchMode SwitchMode {
+            get => (LightColli_SwitchMode)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public LightColli_RangeShape RangeShape {
+            get => (LightColli_RangeShape)ReadInt(4);
+            set => Write(4, (int)value);
+        }
+        public CommonNoYes LightingIsEnabled {
+            get => (CommonNoYes)ReadInt(8);
+            set => Write(8, (int)value);
+        }
+
+        [Description("Presets from the light.bin in the stage folder")]
+        public LightColli_LightNumber LightNumber {
+            get => (LightColli_LightNumber)ReadInt(12);
+            set => Write(12, (int)value);
+        }
+
+        public CommonNoYes EffectIsEmitting {
+            get => (CommonNoYes)ReadInt(16);
+            set => Write(16, (int)value);
+        }
+
+        public int EffectNumber {
+            get => ReadInt(20);
+            set => Write(20, value);
+        }
+
+        public float RangeX {
+            get => ReadFloat(24);
+            set => Write(24, value);
+        }
+
+        public float RangeY {
+            get => ReadFloat(28);
+            set => Write(28, value);
+        }
+
+        public float RangeZ {
+            get => ReadFloat(32);
+            set => Write(32, value);
+        }
+    }
+
+    public enum LightColli_SwitchMode {
+        WhileInRadius,
+        ToggleOn,
+        ToggleOff
+    }
+
+    public enum LightColli_RangeShape {
+        Cylinder,
+        Capsule,
+        Box,
+        Sphere
+    }
+
+    public enum LightColli_LightNumber {
+        // LightNo:PLAYER_0-3; OBJECT_0-3; ENEMY_0-3, KAGE, OTHER_0-2, DoNotUse
+        Player_0,
+        Player_1,
+        Player_2,
+        Player_3,
+        Object_0,
+        Object_1,
+        Object_2,
+        Object_3,
+        Enemy_0,
+        Enemy_1,
+        Enemy_2,
+        Enemy_3,
+        ShadowsOrKage,
+        Other_0,
+        Other_1,
+        Other_2,
+        DoNotUse
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List01/Object012C_EnvironmentalWeapon.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List01/Object012C_EnvironmentalWeapon.cs
@@ -1,0 +1,80 @@
+﻿using System.ComponentModel;
+
+namespace HeroesPowerPlant.LayoutEditor {
+    public class Object012C_EnvironmentalWeapon : SetObjectShadow {
+
+        [Description("Slot was to allow for multiple EW models, never used.")]
+        public int ModelIterUnused {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+
+        [Description("Weapon to drop on destroy.")]
+        public EnvironmentalWeaponDropType WeaponDropType {
+            get => (EnvironmentalWeaponDropType)ReadInt(4);
+            set => Write(4, (int)value);
+        }
+    }
+
+    public enum EnvironmentalWeaponDropType {
+        None=0,
+        Pistol=1,
+        SubMachineGun=2,
+        MachineGun=3,
+        HeavyMachineGun=4,
+        GatlingGun=5,
+        None06=6,
+        EggGun=7,
+        LightShot=8,
+        FlashShot=9,
+        RingShot=10,
+        HeavyShot=11,
+        //address jump
+        GrenadeLauncher=12,
+        GUNBazooka = 13,
+        TankCannon=14,
+        BlackBarrel=15,
+        BigBarrel=16,
+        EggBazooka=17,
+        //address jump
+        RPG=18,
+        FourShot=19,
+        EightShot=20,
+        WormShooterBlack=21,
+        WideWormShooterRed=22,
+        BigWormShooterGold=23,
+        //address jump
+        VacuumPod=24,
+        LaserRifle=25,
+        Splitter=26,
+        Refractor=27,
+        //unfinished F4/F5 weapons occupy 28,29
+        Knife=30,
+        BlackSword=31,
+        DarkHammer=32,
+        EggLance=33,
+        SpeedLimitSign_Westopolis=34, // 00 FE entry
+        DigitalRod_DigitalCircuit=35,
+        Stick_GlyphicCanyon=36,
+        FenceHinge_LethalHighway=37,
+        LanternTorch_CrypticCastle=38,
+        Tree_PrisonIsland=39,
+        EggPole_CircusPark=40,
+        StopSign_CentralCity=41,
+        LightRod_TheDoom=42,
+        Stick_SkyTroops=43,
+        DigitalRod_MadMatrix=44,
+        Tree_DeathRuins=45,
+        UNUSED_TheArk=46,
+        StandLight_AirFleet=47, // 01 0B entry
+        EggStick_IronJungle=48,
+        HexLight_SpaceGadget=49,
+        LightRod_LostImpact=50,
+        StandLight_GUNFortress=51,
+        BkTorchwStand_BlackComet=52,
+        Shovel_LavaShelter=53,
+        HexLight_CosmicFall = 54,
+        BkTorch_FinalHaunt=55,
+        BkTorch_TheLastWay=56
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List03/Object03E9_FallingBuilding.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List03/Object03E9_FallingBuilding.cs
@@ -1,0 +1,17 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object03E9_FallingBuilding : SetObjectShadow {
+        //FallingBuildingHolder obj
+
+        public FallingBuildingType StructureType {
+            get => (FallingBuildingType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+    }
+
+    public enum FallingBuildingType {
+        Bridge15Angle=0,
+        Bridge45Angle=1,
+        Building=2,
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List03/Object03EA_GiantSkyLaser.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List03/Object03EA_GiantSkyLaser.cs
@@ -1,0 +1,19 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object03EA_GiantSkyLaser : SetObjectShadow {
+        public CommonYesNo HurtPlayer {
+            get => (CommonYesNo)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public float DetectRadius {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+
+        public float Delay {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07D1_Searchlight.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07D1_Searchlight.cs
@@ -1,0 +1,24 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object07D1_Searchlight : SetObjectShadow {
+        // ElecSearchLight(ENEMY_ID, RotateRange, RotateSpeed, LightLength)
+        public int SpotOnLinkID { //0 = No or 1 = Yes
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+
+        public float RotateRange {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+
+        public float RotateSpeed {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+        public float LightLength {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07D2_ColorSwitch.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07D2_ColorSwitch.cs
@@ -1,0 +1,30 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object07D2_ColorSwitch : SetObjectShadow {
+        public int type0 { //0 or 1 or 2 or 3
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+        public int type1 { //0 or 1
+            get => ReadInt(4);
+            set => Write(4, value);
+        }
+
+        public float f2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+        public float f3 {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+        public float f4 {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+        public float f5 {
+            get => ReadFloat(20);
+            set => Write(20, value);
+        }
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07D3_RisingLaserBar.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07D3_RisingLaserBar.cs
@@ -1,0 +1,38 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object07D3_RisingLaserBar : SetObjectShadow {
+        public int int0 { //0
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+        public float f1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+
+        public float f2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+        public float f3 {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+        public float f4 {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+        public float f5 {
+            get => ReadFloat(20);
+            set => Write(20, value);
+        }
+        public float f6 {
+            get => ReadFloat(24);
+            set => Write(24, value);
+        }
+        public int int7 { //3, 6
+            get => ReadInt(28);
+            set => Write(28, value);
+        }
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07D5_LightspeedRisingBlock.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07D5_LightspeedRisingBlock.cs
@@ -1,0 +1,35 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object07D5_LightspeedRisingBlock : SetObjectShadow {
+        public int int0 {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+        public float float1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float float2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+        public float float3 {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public float float4 {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+
+        public float float5 {
+            get => ReadFloat(20);
+            set => Write(20, value);
+        }
+
+        public int int6 {
+            get => ReadInt(24);
+            set => Write(24, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07D7_DigitalBreakableTile.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07D7_DigitalBreakableTile.cs
@@ -1,0 +1,16 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object07D7_DigitalBreakableTile : SetObjectShadow {
+        public int int0 {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+        public float float1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float float2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07DF_LightspeedFirewall.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07DF_LightspeedFirewall.cs
@@ -1,0 +1,24 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object07DF_LightspeedFirewall : SetObjectShadow {
+        public float float0 {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+        public float float1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float float2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+        public float float3 {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+        public float float4 {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07E1_TriggerDigitalBreakableTile.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07E1_TriggerDigitalBreakableTile.cs
@@ -1,0 +1,8 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object07E1_TriggerDigitalBreakableTile : SetObjectShadow {
+        public float float0 {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07EB_CubePlatformCircle.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List07/Object07EB_CubePlatformCircle.cs
@@ -1,0 +1,16 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object07EB_CubePlatformCircle : SetObjectShadow {
+        public int int0 {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+        public float float1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float float2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List08/Object0834_TornadoObject1.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List08/Object0834_TornadoObject1.cs
@@ -1,0 +1,54 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0834_TornadoObject1 : SetObjectShadow {
+        public int unk0_int {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+        public float unk0_float {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+        public float float1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float float2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+        public float float3 {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public float float4 {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+
+        public float float5 {
+            get => ReadFloat(20);
+            set => Write(20, value);
+        }
+
+        public float float6 {
+            get => ReadFloat(24);
+            set => Write(24, value);
+        }
+
+        public float float7 {
+            get => ReadFloat(28);
+            set => Write(28, value);
+        }
+
+        public float float8 {
+            get => ReadFloat(32);
+            set => Write(32, value);
+        }
+
+        public float float9 {
+            get => ReadFloat(36);
+            set => Write(36, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List08/Object0835_TornadoObject2.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List08/Object0835_TornadoObject2.cs
@@ -1,0 +1,8 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0835_TornadoObject2 : SetObjectShadow {
+        public float float0 {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List08/Object0836_TornadoObject3.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List08/Object0836_TornadoObject3.cs
@@ -1,0 +1,35 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object0836_TornadoObject3 : SetObjectShadow {
+        public int int0 {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+        public int int1 {
+            get => ReadInt(4);
+            set => Write(4, value);
+        }
+        public float float2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+        public float float3 {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public float float4 {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+
+        public float float5 {
+            get => ReadFloat(20);
+            set => Write(20, value);
+        }
+
+        public float float6 {
+            get => ReadFloat(24);
+            set => Write(24, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List0B/Object0BBE_Chao.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List0B/Object0BBE_Chao.cs
@@ -1,20 +1,20 @@
 ﻿namespace HeroesPowerPlant.LayoutEditor
 {
-    public class Object0BBE_Chao : SetObjectShadow
-    {
+    public class Object0BBE_Chao : SetObjectShadow {
+        //ChaoHolder
         public Chao ChaoType
         {
             get => (Chao)ReadInt(0);
             set => Write(0, (int)value);
         }
 
-        public float Unknown04
+        public float MoveRadius
         {
             get => ReadFloat(4);
             set => Write(4, value);
         }
 
-        public float Unknown08
+        public float MoveSpeed
         {
             get => ReadFloat(8);
             set => Write(8, value);
@@ -23,7 +23,7 @@
 
     public enum Chao
     {
-        Normal = 0x00,
-        Cheese = 0x01
+        Normal = 0x00, //CHAO
+        Cheese = 0x01 //CHEEZ
     }
 }

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List10/Object1069_FleetHolderEggmanBattleship.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List10/Object1069_FleetHolderEggmanBattleship.cs
@@ -1,0 +1,36 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object1069_FleetHolderEggmanBattleship : SetObjectShadow {
+
+        public EggFleetType ShipType {
+            get => (EggFleetType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+        public float RangeRadius {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float RangeHeight {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+        public float MoveLength {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+        public float MoveSpeed {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+
+        public float FireTiming {
+            get => ReadFloat(20);
+            set => Write(20, value);
+        }
+    }
+
+    public enum EggFleetType {
+        BATTLE,
+        MOTHER
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List13/Object1392_SpaceDebris.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List13/Object1392_SpaceDebris.cs
@@ -1,0 +1,20 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object1392_SpaceDebris : SetObjectShadow {
+        public int int0 {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+        public float float1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float float2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+        public float float3 {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List14/Object14BE_ArkGreenLaser.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List14/Object14BE_ArkGreenLaser.cs
@@ -1,0 +1,16 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object14BE_ArkGreenLaser : SetObjectShadow {
+        public float float0 {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+        public float float1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float float2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List17/Object1772_ConcreteDoor.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List17/Object1772_ConcreteDoor.cs
@@ -1,0 +1,20 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object1772_ConcreteDoor : SetObjectShadow {
+        public float float0 {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+        public float float1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float float2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+        public float float3 {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List17/Object1773_CrushingWalls.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List17/Object1773_CrushingWalls.cs
@@ -1,0 +1,12 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object1773_CrushingWalls : SetObjectShadow {
+        public float float0 {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+        public float float1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List17/Object17D4_BAGunShip.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List17/Object17D4_BAGunShip.cs
@@ -1,0 +1,54 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object11D4_BAGunShip : SetObjectShadow {
+
+        public float DetectRangeXZ {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+        public float DetectRangeY {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float TimeUntilTakeOff {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+
+        public BAGunShipAttack Attack {
+            get => (BAGunShipAttack)ReadInt(12);
+            set => Write(12, (int)value);
+        }
+
+        public int int4 {
+            get => ReadInt(16);
+            set => Write(16, value);
+        }
+
+        public int int5 {
+            get => ReadInt(20);
+            set => Write(20, value);
+        }
+
+        public int int6 {
+            get => ReadInt(24);
+            set => Write(24, value);
+        }
+
+        public int int7 {
+            get => ReadInt(28);
+            set => Write(28, value);
+        }
+
+        public float AttackInterval {
+            get => ReadFloat(32);
+            set => Write(32, value);
+        }
+    }
+
+    public enum BAGunShipAttack {
+        NONE,
+        ATTACK,
+        ATTACK2=5
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List17/Object17D5_BlackArmsMine.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List17/Object17D5_BlackArmsMine.cs
@@ -1,0 +1,20 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object17D5_BlackArmsMine : SetObjectShadow {
+        public float float0 {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+        public float float1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float float2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+        public float float3 {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List18/Object1839_RisingLava.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List18/Object1839_RisingLava.cs
@@ -1,0 +1,16 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object1839_RisingLava : SetObjectShadow {
+        public int int0 {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+        public float float1 {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+        public float float2 {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List19/Object1901_CometBarrier.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List19/Object1901_CometBarrier.cs
@@ -1,0 +1,8 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object1901_CometBarrier : SetObjectShadow {
+        public int int0 { //0, 1, 2
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List19/Object1903_BlackDoomHologram.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List19/Object1903_BlackDoomHologram.cs
@@ -1,0 +1,12 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object1903_BlackDoomHologram : SetObjectShadow {
+        public float float0 {
+            get => ReadFloat(0);
+            set => Write(0, value);
+        }
+        public int int1 {
+            get => ReadInt(4);
+            set => Write(4, value);
+        }
+    }
+}

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object258A_Effect1.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object258A_Effect1.cs
@@ -1,0 +1,25 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object258A_Effect1 : SetObjectShadow {
+
+        public int EffectType {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+
+        public float ScaleX {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+
+        public float ScaleY {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+
+        public float ScaleZ {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object2593_SetGenerator.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object2593_SetGenerator.cs
@@ -1,0 +1,41 @@
+﻿using System.ComponentModel;
+
+namespace HeroesPowerPlant.LayoutEditor {
+    public class Object2593_SetGenerator : SetObjectShadow {
+        // AKA EnemySpawner
+
+        [Description("Set an enemy to have a LinkID, then reference that LinkID to select that enemy.")]
+        public int EnemyToSpawnLinkID {
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+        
+        [Description("LinkID to watch for to start spawning enemies. Often activated by Trigger [00 50] of type LinkIDTrigger.")]
+        public int LinkIDToStart {
+            get => ReadInt(4);
+            set => Write(4, value);
+        }
+        
+        [Description("0 is unlimited, Set to cap number of respawns")]
+        public int NumberOfTimesToRespawn {
+            get => ReadInt(8);
+            set => Write(8, value);
+        }
+
+        public float WaitTimeUntilNextRespawn {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public int field4AsInt {
+            get => ReadInt(16);
+            set => Write(16, value);
+        }
+
+        public float field4AsFloat {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object2594_Fan.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object2594_Fan.cs
@@ -1,0 +1,74 @@
+﻿using System.ComponentModel;
+
+namespace HeroesPowerPlant.LayoutEditor {
+    public class Object2594_Fan : SetObjectShadow {
+
+        public FanType FanType { //0 or 1
+            get => (FanType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public FanForm FanForm { //0
+            get => (FanForm)ReadInt(4);
+            set => Write(4, (int)value);
+        }
+
+        public float Radius {
+            get => ReadFloat(8);
+            set => Write(8, value);
+        }
+
+        [Description("Only for FanForm BoxType")]
+        public float BoxTypeAirHeight { //always 0
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        [Description("Cylinder Type Air Height; Box Type Radius")]
+        public float AirHeightANDBoxTypeRadius {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+
+        public float AirStrength {
+            get => ReadFloat(20);
+            set => Write(20, value);
+        }
+
+        public float TimeToRun {
+            get => ReadFloat(24);
+            set => Write(24, value);
+        }
+
+        public float TimeToRecharge {
+            get => ReadFloat(28);
+            set => Write(28, value);
+        }
+
+        public CommonNoYes HasModel { //0 or 1
+            get => (CommonNoYes)ReadInt(32);
+            set => Write(32, (int)value);
+        }
+
+        public FanRunning FanRunning { //-1 or 255
+            get => (FanRunning)ReadInt(36);
+            set => Write(36, (int)value);
+        }
+    }
+
+    public enum FanType {
+        UpperWay,
+        SideWay
+    }
+
+    public enum FanForm {
+        Cylinder,
+        Box,
+    }
+
+    public enum FanRunning {
+        Yes=-1,
+        No=255
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object2595_MissionClearCollision.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object2595_MissionClearCollision.cs
@@ -1,0 +1,21 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object2595_MissionClearCollision : SetObjectShadow {
+
+        public MissionType MissionType {
+            get => (MissionType)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public float Radius {
+            get => ReadFloat(4);
+            set => Write(4, value);
+        }
+    }
+
+    public enum MissionType {
+        Dark,
+        Normal,
+        Hero
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object2597_SetSeLoop.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object2597_SetSeLoop.cs
@@ -1,0 +1,72 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object2597_SetSeLoop : SetObjectShadow {
+
+        public int AudioID {
+            //30017, 29788, 30257, 30542, 30528
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+
+        public KnownAudioIDs KnownAudioIDs {
+            get => (KnownAudioIDs)ReadInt(0);
+            set => Write(0, (int)value);
+        }
+
+        public int RangeTypeMaybeRaw {
+            get => ReadInt(4);
+            set => Write(4, value);
+        }
+
+        public SetSeLoopRange RangeTypeMaybe {
+            get => (SetSeLoopRange)ReadInt(4);
+            set => Write(4, (int)value);
+        }
+
+        public int TypeMaybeRaw {
+            get => ReadInt(8);
+            set => Write(8, value);
+        }
+
+        public SetSeLoopType TypeMaybe {
+            get => (SetSeLoopType)ReadInt(8);
+            set => Write(8, (int)value);
+        }
+
+        public float HalfLengthX {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public float HalfLengthY {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+
+        public float HalfLengthZ {
+            get => ReadFloat(20);
+            set => Write(20, value);
+        }
+
+        public float FlatDampingRate { // FlatDampingRate(0-1)
+            get => ReadFloat(24);
+            set => Write(24, value);
+        }
+    }
+
+    public enum SetSeLoopType {
+        FlatDamping,
+        PanCtrl
+    }
+
+    public enum SetSeLoopRange {
+        Sphere,
+        Box,
+        Cylinder //potentially offset by Capsule if shared with SetSeOneShot
+    }
+
+    public enum KnownAudioIDs {
+        InsectsChirping=30016,
+        WaterFlowing=30026,
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object2598_SetSeOneShot.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/List25/Object2598_SetSeOneShot.cs
@@ -1,0 +1,57 @@
+﻿namespace HeroesPowerPlant.LayoutEditor {
+    public class Object2598_SetSeOneShot : SetObjectShadow {
+
+        public int AudioID { //28980, 29004
+            get => ReadInt(0);
+            set => Write(0, value);
+        }
+
+        public int RangeTypeMaybeRaw {
+            get => ReadInt(4);
+            set => Write(4, value);
+        }
+
+        public SetSeOneShotRange RangeTypeMaybe {
+            get => (SetSeOneShotRange)ReadInt(4);
+            set => Write(4, (int)value);
+        }
+
+        public int TypeMaybeRaw {
+            get => ReadInt(8);
+            set => Write(8, value);
+        }
+
+        public SetSeOneShotType TypeMaybe {
+            get => (SetSeOneShotType)ReadInt(8);
+            set => Write(8, (int)value);
+        }
+
+        public float HalfLengthX {
+            get => ReadFloat(12);
+            set => Write(12, value);
+        }
+
+        public float HalfLengthY {
+            get => ReadFloat(16);
+            set => Write(16, value);
+        }
+
+        public float HalfLengthZ {
+            get => ReadFloat(20);
+            set => Write(20, value);
+        }
+    }
+
+    public enum SetSeOneShotType {
+        OnlyOnce,
+        CallAgain
+    }
+
+    public enum SetSeOneShotRange {
+        Sphere,
+        Box,
+        Capsule,
+        Cylinder
+    }
+}
+

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/ShadowCommonEnums.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/ObjectClassesShadow/ShadowCommonEnums.cs
@@ -1,21 +1,53 @@
 ﻿namespace HeroesPowerPlant.LayoutEditor {
 
-    // common shared enemybase enums (multiple enemy objects share these enums)
     public enum CommonNoYes {
-        NO,
-        YES
+        No,
+        Yes
+    }
+
+    public enum CommonYesNo {
+        Yes,
+        No
     }
 
     public enum CommonWaitActMoveType {
-        STAND,
-        LINEAR,
-        TRIANGLE,
-        RANDOM
+        Stand,
+        Linear,
+        Triangle,
+        Random
     }
 
     public enum CommonActionType {
-        NONE,
-        ATTACK,
-        HIDE
+        None,
+        Attack,
+        Hide
     }
+
+    public enum EnergyCoreType {
+        NotValidInObject=-1,
+        Hero=0,
+        Dark=1
+    }
+
+    public enum BoxType {
+        GUN,
+        BlackArms,
+        Eggman
+    }
+
+    public enum BoxItem {
+        NotValidInObject=-1,
+        Nothing=0,
+        ItemCapsule,
+        Weapon,
+        DropNumOfRings,
+        HealUnit,
+        EnergyCore,
+        ShadowSpecialWeapons,
+    }
+
+    /*
+     * 
+    public string Note => "Not all misc. settings are in list yet.";
+    */
 }

--- a/HeroesPowerPlant/LayoutEditor/SetObjects/RingType.cs
+++ b/HeroesPowerPlant/LayoutEditor/SetObjects/RingType.cs
@@ -5,6 +5,7 @@
         Normal = 0,
         Line = 1,
         Circle = 2,
-        Arch = 3
+        Arch = 3,
+        WarpToPlayerIfAtSpawn = 1092616192
     }
 }

--- a/HeroesPowerPlant/Resources/Lists/ShadowObjectList.ini
+++ b/HeroesPowerPlant/Resources/Lists/ShadowObjectList.ini
@@ -157,6 +157,9 @@ Object=Target Switch
 MiscSettingCount=24
 Model=TARGETSW00.DFF,TARGETSW01.DFF,TARGETSW02.DFF
 
+[00][18]
+Object=UnknownPrisonIsland
+
 [00][19]
 Object=Weight
 MiscSettingCount=36
@@ -280,6 +283,9 @@ ModelMiscSetting=0
 Model=CT0100TURNOVER.DFF,CT0202HIKKURI.DFF,PR0300TURNOVER.DFF,JG0301TURNOVERSM.DFF,A20000TURNOVER.DFF,JG0404TURNOVERSM.DFF,BS0000HIKKURI.DFF,JG0502TURNOVER.DFF,A10503TURNOVER.DFF,BS0602HIKKURI.DFF,A10603TURNOVER.DFF
 Model=JG0301TURNOVERLG.DFF,JG0404TURNOVERLG.DFF
 
+[00][32]
+Object=UnknownDeathRuinsIronJungle
+
 [00][33]
 Object=Energy Core
 MiscSettingCount=4
@@ -289,7 +295,7 @@ Object=Fire
 MiscSettingCount=12
 
 [00][35]
-Object=Green Gas
+Object=Poison Gas
 MiscSettingCount=12
 
 [00][37]
@@ -301,6 +307,9 @@ Model=CAPTCAGE.DFF,CAPTCAGE1.DFF
 Object=Heal Unit
 MiscSettingCount=0
 Model=HEALUNIT.DFF,HUCAP.DFF,HUCORE.DFF,HULIGHT.DFF
+
+[00][39]
+Object=UnknownEggDealerBlackComet
 
 [00][3A]
 Object=Special Weapon Box
@@ -333,9 +342,25 @@ MiscSettingCount=28
 Object=Trigger: Talking
 MiscSettingCount=40
 
+[00][52]
+Object=UnknownMulti2
+#Westopolis,Glyphic,Lethal
+
+[00][53]
+Object=UnknownMulti3
+#Westopolis,Glyphic,Lethal
+
+[00][54]
+Object=UnknownMulti4
+#Westopolis,Glyphic,Lethal
+
+[00][55]
+Object=UnknownMulti5
+#Westopolis,Glyphic,Lethal
+
 [00][59]
-Object=Trigger: ?Skybox Hide?
-#stg0201 cmn
+Object=Trigger: Skybox
+#stg0201 cmn and 0402
 
 [00][5A]
 Object=Pole
@@ -365,6 +390,9 @@ Model=BEETLEGOLD.DFF,BEETLEGOLDLIGHT.DFF
 Object=GUN Big Foot
 MiscSettingCount=40
 Model=BIGFOOTA.DFF
+
+[00][67]
+Object=DeathRuinsUNKNOWN
 
 [00][68]
 Object=GUN Robot
@@ -517,6 +545,9 @@ Object=Giant Sky Laser
 MiscSettingCount=12
 #Model=CT0100CITYLASERPREDICT.DFF
 #Model=CT0100CITYLASER.DFF
+
+[07][D0]
+Object=UnknownDigitalCircuit
 
 [07][D1]
 Object=Searchlight
@@ -692,6 +723,9 @@ Model=CN0201POWERDEVICEBARRIER.DFF
 Object=Matrix Sphere
 MiscSettingCount=0
 
+[08][98]
+Object=UnknownLethalHighway
+
 [08][99]
 Object=Black Tank Pathing
 MiscSettingCount=24
@@ -710,6 +744,9 @@ Model=CT0202GUNBUILDING.DFF
 Object=Falling Road
 MiscSettingCount=4
 Model=CT0202FALLROAD00.DFF
+
+[0B][BA]
+Object=UnknownCrypticCastle
 
 [0B][BB]
 Object=Small Lantern
@@ -951,6 +988,9 @@ Model=A10000STAIR.DFF
 Model=A10000TABLE.DFF
 Model=A10000ARKDEBRIS.DFF
 
+[13][EC]
+Object=UnknownAirFleet
+
 [13][ED]
 Object=Escape Pod Path Switch
 MiscSettingCount=4
@@ -985,8 +1025,11 @@ Object=Escape Pod Down Rail
 MiscSettingCount=8
 Model=BS0501UPDOWNRAIL.DFF
 
+[14][50]
+Object=IronJungleUnknown
+
 [14][51]
-Object=Egg Balloon Trigger?
+Object=CommandCollision (Egg Balloon)
 MiscSettingCount=24
 
 [14][53]
@@ -1016,6 +1059,9 @@ Model=A10503GRVBOARD.DFF
 [14][BE]
 Object=ARK Green Laser
 MiscSettingCount=12
+
+[15][18]
+Object=UnknownLostImpact
 
 [17][70]
 Object=GUN Camera
@@ -1429,28 +1475,31 @@ Model=A20000DIRECTION.DFF
 Model=A20000HEXLIGHTS.DFF
 
 [25][93]
-Object=Unknown?EnemySpawner?
+Object=EnemySpawner
 MiscSettingCount=20
 #stg0511 cmn
 
 [25][94]
-Object=Decoration: Fan
+Object=Fan
 #stg0401 cmn
 
 [25][95]
-Object=Unknown
+Object=MissionClearCollision
+MiscSettingCount=8
 #stg0603 nrm
 
 [25][96]
-Object=Unknown Boss Object
+Object=HintController for Boss
 MiscSettingCount=0
 
 [25][97]
-Object=Unknown
+Object=SetSeLoop
+MiscSettingCount=28
 #stg0301 ds1
 
 [25][98]
-Object=Unknown
+Object=SetSeOneShot
+MiscSettingCount=24
 #stg0100 ds1
 
 [00][46]


### PR DESCRIPTION
Lots of misc byte definitions in this merge. Figured it was better to break it up into a few PR.

Objects can be of 3 states:
-  Defines types, but not names/functionality - these are low priority but only ones that I have 100% confirmed have types declared.
- Complete definition - 100% finished and accurate
- Partial - Contain some names, but also some unknown types.


I also introduce (-1) for some enum types to handle the few objects that lack misc bytes to maintain 1:1 with original game files.
An example of this is Metal Box, where some instances have 4 bytes, 8 bytes, or 12 bytes.


Finally, I have corrected some names in the .ini and added a few new ones that I've identified as well as a few new unknown entries (temporary- I am defining those next PR)