### PR TITLE
Option to export all splines for Heroes

### DIFF
--- a/HeroesPowerPlant/ConfigEditor/SplineEditor/SplineEditor.cs
+++ b/HeroesPowerPlant/ConfigEditor/SplineEditor/SplineEditor.cs
@@ -177,7 +177,7 @@ namespace HeroesPowerPlant.SplineEditor
         {
             if (listBoxSplines.SelectedIndex >= 0 && listBoxSplines.SelectedIndex < splineEditorFunctions.GetSplineCount())
             {
-                using VistaSaveFileDialog saveFile = new VistaSaveFileDialog() { Filter = "*.obj|OBJ files" };
+                using VistaSaveFileDialog saveFile = new VistaSaveFileDialog() { Filter = "*.obj|OBJ files|*.*|All Files" };
                 if (saveFile.ShowDialog() == DialogResult.OK)
                     splineEditorFunctions.ExportOBJ(saveFile.FileName, checkBoxExportAll.Checked);
             }

--- a/HeroesPowerPlant/ConfigEditor/SplineEditor/SplineEditor.cs
+++ b/HeroesPowerPlant/ConfigEditor/SplineEditor/SplineEditor.cs
@@ -177,9 +177,9 @@ namespace HeroesPowerPlant.SplineEditor
         {
             if (listBoxSplines.SelectedIndex >= 0 && listBoxSplines.SelectedIndex < splineEditorFunctions.GetSplineCount())
             {
-                using VistaSaveFileDialog saveFile = new VistaSaveFileDialog() { Filter = "*.obj|OBJ files|*.*|All Files" };
+                using VistaSaveFileDialog saveFile = new VistaSaveFileDialog() { Filter = "*.obj|OBJ files" };
                 if (saveFile.ShowDialog() == DialogResult.OK)
-                    splineEditorFunctions.ExportOBJ(saveFile.FileName);
+                    splineEditorFunctions.ExportOBJ(saveFile.FileName, checkBoxExportAll.Checked);
             }
         }
 

--- a/HeroesPowerPlant/ConfigEditor/SplineEditor/SplineEditor.designer.cs
+++ b/HeroesPowerPlant/ConfigEditor/SplineEditor/SplineEditor.designer.cs
@@ -42,6 +42,7 @@
             this.buttonAutoPitchSpline = new System.Windows.Forms.Button();
             this.buttonAutoPitchAll = new System.Windows.Forms.Button();
             this.buttonExportOBJ = new System.Windows.Forms.Button();
+            this.checkBoxExportAll = new System.Windows.Forms.CheckBox();
             this.groupBoxPitchRoll.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownRoll)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownPitch)).BeginInit();
@@ -50,9 +51,11 @@
             // listBoxSplines
             // 
             this.listBoxSplines.FormattingEnabled = true;
-            this.listBoxSplines.Location = new System.Drawing.Point(12, 41);
+            this.listBoxSplines.ItemHeight = 15;
+            this.listBoxSplines.Location = new System.Drawing.Point(14, 47);
+            this.listBoxSplines.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.listBoxSplines.Name = "listBoxSplines";
-            this.listBoxSplines.Size = new System.Drawing.Size(109, 134);
+            this.listBoxSplines.Size = new System.Drawing.Size(126, 154);
             this.listBoxSplines.TabIndex = 9;
             this.listBoxSplines.SelectedIndexChanged += new System.EventHandler(this.listBoxSplines_SelectedIndexChanged);
             // 
@@ -64,17 +67,19 @@
             "Loop",
             "Rail",
             "Ball"});
-            this.comboBoxType.Location = new System.Drawing.Point(127, 41);
+            this.comboBoxType.Location = new System.Drawing.Point(148, 47);
+            this.comboBoxType.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.comboBoxType.Name = "comboBoxType";
-            this.comboBoxType.Size = new System.Drawing.Size(109, 21);
+            this.comboBoxType.Size = new System.Drawing.Size(126, 23);
             this.comboBoxType.TabIndex = 10;
             this.comboBoxType.SelectedIndexChanged += new System.EventHandler(this.comboBoxType_SelectedIndexChanged);
             // 
             // buttonDelete
             // 
-            this.buttonDelete.Location = new System.Drawing.Point(62, 12);
+            this.buttonDelete.Location = new System.Drawing.Point(72, 14);
+            this.buttonDelete.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonDelete.Name = "buttonDelete";
-            this.buttonDelete.Size = new System.Drawing.Size(59, 23);
+            this.buttonDelete.Size = new System.Drawing.Size(69, 27);
             this.buttonDelete.TabIndex = 11;
             this.buttonDelete.Text = "Delete";
             this.buttonDelete.UseVisualStyleBackColor = true;
@@ -82,9 +87,10 @@
             // 
             // buttonAdd
             // 
-            this.buttonAdd.Location = new System.Drawing.Point(12, 12);
+            this.buttonAdd.Location = new System.Drawing.Point(14, 14);
+            this.buttonAdd.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonAdd.Name = "buttonAdd";
-            this.buttonAdd.Size = new System.Drawing.Size(44, 23);
+            this.buttonAdd.Size = new System.Drawing.Size(51, 27);
             this.buttonAdd.TabIndex = 11;
             this.buttonAdd.Text = "Add";
             this.buttonAdd.UseVisualStyleBackColor = true;
@@ -93,9 +99,10 @@
             // buttonSave
             // 
             this.buttonSave.Enabled = false;
-            this.buttonSave.Location = new System.Drawing.Point(127, 12);
+            this.buttonSave.Location = new System.Drawing.Point(148, 14);
+            this.buttonSave.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonSave.Name = "buttonSave";
-            this.buttonSave.Size = new System.Drawing.Size(109, 23);
+            this.buttonSave.Size = new System.Drawing.Size(127, 27);
             this.buttonSave.TabIndex = 12;
             this.buttonSave.Text = "Save Splines";
             this.buttonSave.UseVisualStyleBackColor = true;
@@ -103,9 +110,10 @@
             // 
             // buttonViewHere
             // 
-            this.buttonViewHere.Location = new System.Drawing.Point(242, 41);
+            this.buttonViewHere.Location = new System.Drawing.Point(282, 47);
+            this.buttonViewHere.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonViewHere.Name = "buttonViewHere";
-            this.buttonViewHere.Size = new System.Drawing.Size(128, 21);
+            this.buttonViewHere.Size = new System.Drawing.Size(149, 24);
             this.buttonViewHere.TabIndex = 62;
             this.buttonViewHere.Text = "View Here";
             this.buttonViewHere.UseVisualStyleBackColor = true;
@@ -114,9 +122,11 @@
             // listBoxPoints
             // 
             this.listBoxPoints.FormattingEnabled = true;
-            this.listBoxPoints.Location = new System.Drawing.Point(127, 67);
+            this.listBoxPoints.ItemHeight = 15;
+            this.listBoxPoints.Location = new System.Drawing.Point(148, 77);
+            this.listBoxPoints.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.listBoxPoints.Name = "listBoxPoints";
-            this.listBoxPoints.Size = new System.Drawing.Size(109, 134);
+            this.listBoxPoints.Size = new System.Drawing.Size(126, 154);
             this.listBoxPoints.TabIndex = 63;
             this.listBoxPoints.SelectedIndexChanged += new System.EventHandler(this.listBoxPoints_SelectedIndexChanged);
             // 
@@ -126,18 +136,21 @@
             this.groupBoxPitchRoll.Controls.Add(this.numericUpDownRoll);
             this.groupBoxPitchRoll.Controls.Add(this.numericUpDownPitch);
             this.groupBoxPitchRoll.Enabled = false;
-            this.groupBoxPitchRoll.Location = new System.Drawing.Point(242, 68);
+            this.groupBoxPitchRoll.Location = new System.Drawing.Point(282, 78);
+            this.groupBoxPitchRoll.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.groupBoxPitchRoll.Name = "groupBoxPitchRoll";
-            this.groupBoxPitchRoll.Size = new System.Drawing.Size(128, 100);
+            this.groupBoxPitchRoll.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.groupBoxPitchRoll.Size = new System.Drawing.Size(149, 115);
             this.groupBoxPitchRoll.TabIndex = 64;
             this.groupBoxPitchRoll.TabStop = false;
             this.groupBoxPitchRoll.Text = "Pitch, Roll";
             // 
             // buttonAutoPitchPoint
             // 
-            this.buttonAutoPitchPoint.Location = new System.Drawing.Point(6, 71);
+            this.buttonAutoPitchPoint.Location = new System.Drawing.Point(7, 82);
+            this.buttonAutoPitchPoint.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonAutoPitchPoint.Name = "buttonAutoPitchPoint";
-            this.buttonAutoPitchPoint.Size = new System.Drawing.Size(116, 23);
+            this.buttonAutoPitchPoint.Size = new System.Drawing.Size(135, 27);
             this.buttonAutoPitchPoint.TabIndex = 65;
             this.buttonAutoPitchPoint.Text = "AutoPitch Point";
             this.buttonAutoPitchPoint.UseVisualStyleBackColor = true;
@@ -146,36 +159,39 @@
             // numericUpDownRoll
             // 
             this.numericUpDownRoll.DecimalPlaces = 4;
-            this.numericUpDownRoll.Location = new System.Drawing.Point(6, 45);
+            this.numericUpDownRoll.Location = new System.Drawing.Point(7, 52);
+            this.numericUpDownRoll.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.numericUpDownRoll.Maximum = new decimal(new int[] {
             360,
             0,
             0,
             0});
             this.numericUpDownRoll.Name = "numericUpDownRoll";
-            this.numericUpDownRoll.Size = new System.Drawing.Size(116, 20);
+            this.numericUpDownRoll.Size = new System.Drawing.Size(135, 23);
             this.numericUpDownRoll.TabIndex = 1;
             this.numericUpDownRoll.ValueChanged += new System.EventHandler(this.numericUpDown_ValueChanged);
             // 
             // numericUpDownPitch
             // 
             this.numericUpDownPitch.DecimalPlaces = 4;
-            this.numericUpDownPitch.Location = new System.Drawing.Point(6, 19);
+            this.numericUpDownPitch.Location = new System.Drawing.Point(7, 22);
+            this.numericUpDownPitch.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.numericUpDownPitch.Maximum = new decimal(new int[] {
             360,
             0,
             0,
             0});
             this.numericUpDownPitch.Name = "numericUpDownPitch";
-            this.numericUpDownPitch.Size = new System.Drawing.Size(116, 20);
+            this.numericUpDownPitch.Size = new System.Drawing.Size(135, 23);
             this.numericUpDownPitch.TabIndex = 0;
             this.numericUpDownPitch.ValueChanged += new System.EventHandler(this.numericUpDown_ValueChanged);
             // 
             // buttonAutoPitchSpline
             // 
-            this.buttonAutoPitchSpline.Location = new System.Drawing.Point(248, 174);
+            this.buttonAutoPitchSpline.Location = new System.Drawing.Point(289, 201);
+            this.buttonAutoPitchSpline.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonAutoPitchSpline.Name = "buttonAutoPitchSpline";
-            this.buttonAutoPitchSpline.Size = new System.Drawing.Size(116, 23);
+            this.buttonAutoPitchSpline.Size = new System.Drawing.Size(135, 27);
             this.buttonAutoPitchSpline.TabIndex = 66;
             this.buttonAutoPitchSpline.Text = "AutoPitch Spline";
             this.buttonAutoPitchSpline.UseVisualStyleBackColor = true;
@@ -183,9 +199,10 @@
             // 
             // buttonAutoPitchAll
             // 
-            this.buttonAutoPitchAll.Location = new System.Drawing.Point(242, 12);
+            this.buttonAutoPitchAll.Location = new System.Drawing.Point(282, 14);
+            this.buttonAutoPitchAll.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonAutoPitchAll.Name = "buttonAutoPitchAll";
-            this.buttonAutoPitchAll.Size = new System.Drawing.Size(128, 23);
+            this.buttonAutoPitchAll.Size = new System.Drawing.Size(149, 27);
             this.buttonAutoPitchAll.TabIndex = 67;
             this.buttonAutoPitchAll.Text = "AutoPitch All";
             this.buttonAutoPitchAll.UseVisualStyleBackColor = true;
@@ -193,20 +210,31 @@
             // 
             // buttonExportOBJ
             // 
-            this.buttonExportOBJ.Enabled = true;
-            this.buttonExportOBJ.Location = new System.Drawing.Point(12, 178);
+            this.buttonExportOBJ.Location = new System.Drawing.Point(14, 205);
+            this.buttonExportOBJ.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonExportOBJ.Name = "buttonExportOBJ";
-            this.buttonExportOBJ.Size = new System.Drawing.Size(109, 23);
+            this.buttonExportOBJ.Size = new System.Drawing.Size(127, 27);
             this.buttonExportOBJ.TabIndex = 68;
             this.buttonExportOBJ.Text = "Export OBJ";
             this.buttonExportOBJ.UseVisualStyleBackColor = true;
             this.buttonExportOBJ.Click += new System.EventHandler(this.buttonExportOBJ_Click);
             // 
+            // checkBoxExportAll
+            // 
+            this.checkBoxExportAll.AutoSize = true;
+            this.checkBoxExportAll.Location = new System.Drawing.Point(16, 237);
+            this.checkBoxExportAll.Name = "checkBoxExportAll";
+            this.checkBoxExportAll.Size = new System.Drawing.Size(117, 19);
+            this.checkBoxExportAll.TabIndex = 69;
+            this.checkBoxExportAll.Text = "Export All Splines";
+            this.checkBoxExportAll.UseVisualStyleBackColor = true;
+            // 
             // SplineEditor
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(377, 206);
+            this.ClientSize = new System.Drawing.Size(440, 260);
+            this.Controls.Add(this.checkBoxExportAll);
             this.Controls.Add(this.buttonExportOBJ);
             this.Controls.Add(this.buttonAutoPitchAll);
             this.Controls.Add(this.buttonAutoPitchSpline);
@@ -219,6 +247,7 @@
             this.Controls.Add(this.comboBoxType);
             this.Controls.Add(this.listBoxSplines);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.MaximizeBox = false;
             this.Name = "SplineEditor";
             this.ShowIcon = false;
@@ -228,6 +257,7 @@
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownRoll)).EndInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownPitch)).EndInit();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
 
@@ -247,5 +277,6 @@
         private System.Windows.Forms.Button buttonAutoPitchSpline;
         private System.Windows.Forms.Button buttonAutoPitchAll;
         public System.Windows.Forms.Button buttonExportOBJ;
+        private System.Windows.Forms.CheckBox checkBoxExportAll;
     }
 }

--- a/HeroesPowerPlant/ConfigEditor/SplineEditor/SplineEditorFunctions.cs
+++ b/HeroesPowerPlant/ConfigEditor/SplineEditor/SplineEditorFunctions.cs
@@ -226,16 +226,45 @@ namespace HeroesPowerPlant.SplineEditor
                 SplineList.Add(new Spline(spline.Vertices, ToSplineType(spline.SplineType), renderer));
         }
 
-        internal void ExportOBJ(string fileName)
+        internal void ExportOBJ(string fileName, bool exportAll = false)
         {
+            // Append .obj to the file name if it isn't already there.
+            if (!fileName.EndsWith(".obj") && !exportAll)
+                fileName += ".obj";
+
+            // If we're only exporting this one spline, then call the Write function with the value of CurrentlySelectedObject.
+            if (!exportAll)
+                WriteOBJ(fileName, CurrentlySelectedObject);
+
+            // If we're exporting all the splines, loop through and call the Write function for each.
+            else
+                for (int s = 0; s < SplineList.Count; s++)
+                    WriteOBJ($"{fileName}{s}.obj", s);
+        }
+
+        private void WriteOBJ(string fileName, int splineIndex)
+        {
+            // Set up a StreamWriter.
             using StreamWriter writer = new StreamWriter(new FileStream(fileName, FileMode.Create));
             {
+                // Write the HPP credit header.
                 writer.WriteLine("# Exported by Heroes Power Plant");
-                foreach (var v in SplineList[CurrentlySelectedObject].Points)
+
+                // Write each vertex coordinate.
+                foreach (var v in SplineList[splineIndex].Points)
                     writer.WriteLine($"v {v.Position.X} {v.Position.Y} {v.Position.Z} {v.Roll} {v.Pitch}");
+
+                // Name the spline.
+                writer.WriteLine($"\r\no Spline{splineIndex + 1}\r\ng Spline{splineIndex + 1}");
+
+                // Set up the line.
                 string l = "l ";
-                for (int i = 0; i < SplineList[CurrentlySelectedObject].Points.Length; i++)
-                    l += $"{i} ";
+
+                // Add each vertex index to the spline line, incremented by 1 as OBJ starts from 1 not 0.
+                for (int i = 0; i < SplineList[splineIndex].Points.Length; i++)
+                    l += $"{i + 1} ";
+
+                // Write the line value to the OBJ.
                 writer.WriteLine(l);
             }
         }


### PR DESCRIPTION
Adds a checkbox to the Heroes Spline Editor that will export every loaded spline to the specified path when exporting, rather than just one, appending the spline's number to the end of the filename for each spline.

This also adjusts the single spline export, as it seemed broken, not naming the object and starting to count nodes from 0, whereas OBJ seems to start from 1 (at least when it comes to 3DS Max?). Also removes the All Files filter from the exporter and makes sure the filename has an .obj extension, as previously it was possible to end up with no extension on the outputted file.

![image](https://user-images.githubusercontent.com/10520977/218589248-b31ae3df-3c28-44ba-8c22-f5b627c78d1c.png)
