### PR TITLE
Use generic SetObject type when exporting INI

### DIFF
--- a/HeroesPowerPlant/LayoutEditor/LayoutEditorFunctions.cs
+++ b/HeroesPowerPlant/LayoutEditor/LayoutEditorFunctions.cs
@@ -367,7 +367,7 @@ namespace HeroesPowerPlant.LayoutEditor
             return list;
         }
 
-        public static void SaveHeroesLayoutINI(IEnumerable<SetObjectHeroes> list, string outputFile)
+        public static void SaveLayoutINI(IEnumerable<SetObject> list, string outputFile)
         {
             var iniWriter = new StreamWriter(new FileStream(outputFile, FileMode.Create));
             iniWriter.WriteLine("#Exported by HeroesPowerPlant");

--- a/HeroesPowerPlant/LayoutEditor/LayoutEditorSystem.cs
+++ b/HeroesPowerPlant/LayoutEditor/LayoutEditorSystem.cs
@@ -150,7 +150,7 @@ namespace HeroesPowerPlant.LayoutEditor
 
         public void SaveINI(string fileName)
         {
-            SaveHeroesLayoutINI(setObjects.Cast<SetObjectHeroes>(), fileName);
+            SaveLayoutINI(setObjects.Cast<SetObject>(), fileName);
         }
 
         public void ImportINI(string fileName)


### PR DESCRIPTION
When trying to export an INI to Shadow stages, HeroesPowerPlant fails since it tries to cast the set objects into Heroes ones. Using the generic SetObject class instead of the Heroes specific one solves this issue.