### PR TITLE
Fix incorrect data type in Sonic Heroes visibility table writing

### DIFF
--- a/HeroesPowerPlant/LevelEditor/Visibility/VisibilityFunctions.cs
+++ b/HeroesPowerPlant/LevelEditor/Visibility/VisibilityFunctions.cs
@@ -101,12 +101,12 @@ namespace HeroesPowerPlant.LevelEditor
                     continue;
                 writer.Write(i.number);
 
-                writer.Write(i.Min.X);
-                writer.Write(i.Min.Y);
-                writer.Write(i.Min.Z);
-                writer.Write(i.Max.X);
-                writer.Write(i.Max.Y);
-                writer.Write(i.Max.Z);
+                writer.Write((int)i.Min.X);
+                writer.Write((int)i.Min.Y);
+                writer.Write((int)i.Min.Z);
+                writer.Write((int)i.Max.X);
+                writer.Write((int)i.Max.Y);
+                writer.Write((int)i.Max.Z);
             }
         }
 


### PR DESCRIPTION
When reading a Sonic Heroes BLK file, HeroesPowerPlant creates a Vector3 out of the integer values read from the file, but when it writes them, it writes the float values within the Vector3 back, creating incorrect outputs (such as -4000 being saved as -981860352).
This commit simply casts the values in the Vector3 to signed ints before writing to fix this behaviour.

It also seems like the second half of the BLK format isn't read or written by the software. Is this an issue or does the game function correctly without that chunk of data?