### PR TITLE
Isolated Chunk Viewing

### DIFF
--- a/HeroesPowerPlant/LevelEditor/LevelEditor.cs
+++ b/HeroesPowerPlant/LevelEditor/LevelEditor.cs
@@ -997,6 +997,38 @@ namespace HeroesPowerPlant.LevelEditor
             }
         }
 
+        private void buttonIsolateChunk_Click(object sender, EventArgs e)
+        {
+            // Set up a list of level model indices to be hidden.
+            List<int> indicesToHide = new();
+
+            // Recheck all the level models in the list view.
+            foreach (ListViewItem item in listViewLevelModels.Items)
+                item.Checked = true;
+
+            // Loop through each entry in the BSP list.
+            for (int bspIndex = 0; bspIndex < bspRenderer.BSPList.Count; bspIndex++)
+            {
+                // Check if this BSP's chunk index doesn't match the selected visiblity block's chunk value.
+                if (bspRenderer.BSPList[bspIndex].ChunkNumber != NumChunkNum.Value)
+                {
+                    // Hide this chunk.
+                    bspRenderer.BSPList[bspIndex].isVisible = false;
+
+                    // Mark the index of this BSP to be hidden.
+                    indicesToHide.Add(bspIndex);
+                }
+
+                // If not, then make this chunk visible.
+                else
+                    bspRenderer.BSPList[bspIndex].isVisible = true;
+            }
+
+            // Loop through and uncheck each level model in our list of indices.
+            foreach (int index in indicesToHide)
+                listViewLevelModels.Items[index].Checked = false;
+        }
+
         private bool _unsavedChangesLevel = false;
         private bool _unsavedChangesVisibility = false;
 

--- a/HeroesPowerPlant/LevelEditor/LevelEditor.cs
+++ b/HeroesPowerPlant/LevelEditor/LevelEditor.cs
@@ -21,6 +21,9 @@ namespace HeroesPowerPlant.LevelEditor
 {
     public partial class LevelEditor : Form, IUnsavedChanges
     {
+        // Internal value to determine if chunk isolation is active.
+        private bool isolationActive = false;
+
         protected override void OnFormClosing(FormClosingEventArgs e)
         {
             if (e.CloseReason == CloseReason.WindowsShutDown)
@@ -857,6 +860,12 @@ namespace HeroesPowerPlant.LevelEditor
             }
 
             ProgramIsChangingStuff = false;
+
+            // Change the isolation button text.
+            buttonIsolateChunk.Text = "Isolate Chunk";
+
+            // Disable the isolation flag.
+            isolationActive = false;
         }
 
         private void buttonAddChunkClick(object sender, EventArgs e)
@@ -1000,34 +1009,56 @@ namespace HeroesPowerPlant.LevelEditor
 
         private void buttonIsolateChunk_Click(object sender, EventArgs e)
         {
-            // Set up a list of level model indices to be hidden.
-            List<int> indicesToHide = new();
-
             // Recheck all the level models in the list view.
             foreach (ListViewItem item in listViewLevelModels.Items)
                 item.Checked = true;
 
-            // Loop through each entry in the BSP list.
-            for (int bspIndex = 0; bspIndex < bspRenderer.BSPList.Count; bspIndex++)
+            // Check if the isolation isn't active.
+            if (!isolationActive)
             {
-                // Check if this BSP's chunk index doesn't match the selected visiblity block's chunk value.
-                if (bspRenderer.BSPList[bspIndex].ChunkNumber != NumChunkNum.Value)
-                {
-                    // Hide this chunk.
-                    bspRenderer.BSPList[bspIndex].isVisible = false;
+                // Set up a list of level model indices to be hidden.
+                List<int> indicesToHide = new();
 
-                    // Mark the index of this BSP to be hidden.
-                    indicesToHide.Add(bspIndex);
+                // Loop through each entry in the BSP list.
+                for (int bspIndex = 0; bspIndex < bspRenderer.BSPList.Count; bspIndex++)
+                {
+                    // Check if this BSP's chunk index doesn't match the selected visiblity block's chunk value.
+                    if (bspRenderer.BSPList[bspIndex].ChunkNumber != NumChunkNum.Value)
+                    {
+                        // Hide this chunk.
+                        bspRenderer.BSPList[bspIndex].isVisible = false;
+
+                        // Mark the index of this BSP to be hidden.
+                        indicesToHide.Add(bspIndex);
+                    }
+
+                    // If not, then make this chunk visible.
+                    else
+                        bspRenderer.BSPList[bspIndex].isVisible = true;
                 }
 
-                // If not, then make this chunk visible.
-                else
-                    bspRenderer.BSPList[bspIndex].isVisible = true;
-            }
+                // Loop through and uncheck each level model in our list of indices.
+                foreach (int index in indicesToHide)
+                    listViewLevelModels.Items[index].Checked = false;
 
-            // Loop through and uncheck each level model in our list of indices.
-            foreach (int index in indicesToHide)
-                listViewLevelModels.Items[index].Checked = false;
+                // Change the button text.
+                buttonIsolateChunk.Text = "Disable Isolation";
+
+                // Set the isolation flag.
+                isolationActive = true;
+            }
+            else
+            {
+                // Loop through and make every chunk visible.
+                for (int bspIndex = 0; bspIndex < bspRenderer.BSPList.Count; bspIndex++)
+                    bspRenderer.BSPList[bspIndex].isVisible = true;
+
+                // Change the button text.
+                buttonIsolateChunk.Text = "Isolate Chunk";
+
+                // Disable the isolation flag.
+                isolationActive = false;
+            }
         }
 
         private bool _unsavedChangesLevel = false;

--- a/HeroesPowerPlant/LevelEditor/LevelEditor.designer.cs
+++ b/HeroesPowerPlant/LevelEditor/LevelEditor.designer.cs
@@ -90,6 +90,7 @@
             ButtonReassignMATFlag = new System.Windows.Forms.Button();
             textBox_import_extension = new System.Windows.Forms.TextBox();
             label_import_extension = new System.Windows.Forms.Label();
+            buttonIsolateChunk = new System.Windows.Forms.Button();
             groupBox1.SuspendLayout();
             groupBox2.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)numericCurrentChunk).BeginInit();
@@ -238,6 +239,7 @@
             // 
             // groupBox2
             // 
+            groupBox2.Controls.Add(buttonIsolateChunk);
             groupBox2.Controls.Add(buttonAutoBuild);
             groupBox2.Controls.Add(labelChunkAmount);
             groupBox2.Controls.Add(label3);
@@ -708,6 +710,17 @@
             label_import_extension.TabIndex = 26;
             label_import_extension.Text = "Import Extension";
             // 
+            // buttonIsolateChunk
+            // 
+            buttonIsolateChunk.Location = new System.Drawing.Point(7, 89);
+            buttonIsolateChunk.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            buttonIsolateChunk.Name = "buttonIsolateChunk";
+            buttonIsolateChunk.Size = new System.Drawing.Size(134, 27);
+            buttonIsolateChunk.TabIndex = 28;
+            buttonIsolateChunk.Text = "Isolate Chunk";
+            buttonIsolateChunk.UseVisualStyleBackColor = true;
+            buttonIsolateChunk.Click += buttonIsolateChunk_Click;
+            // 
             // LevelEditor
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
@@ -816,5 +829,7 @@
         private System.Windows.Forms.ListView listViewLevelModels;
         private System.Windows.Forms.ColumnHeader file;
         private System.Windows.Forms.ToolStripMenuItem ShadowLevelMenuItemSaveSplineDataOnly;
+        private System.Windows.Forms.Button button1;
+        private System.Windows.Forms.Button buttonIsolateChunk;
     }
 }


### PR DESCRIPTION
Adds a button to the level editor that hides all the models that are not associated with the currently selected visibility block's chunk.

Implemented to handle issue https://github.com/igorseabra4/HeroesPowerPlant/issues/38


https://github.com/user-attachments/assets/5c1eb537-1c7e-4e6b-a654-df985d8286ae

