### PR TITLE
Feature: Shadow ADB Texture Animation support

### DIFF
--- a/HeroesPowerPlant/HeroesPowerPlant.csproj
+++ b/HeroesPowerPlant/HeroesPowerPlant.csproj
@@ -191,6 +191,9 @@
     <Compile Update="MainForm\ViewConfig.designer.cs">
       <DependentUpon>ViewConfig.cs</DependentUpon>
     </Compile>
+    <Compile Update="ShadowTexturePatternEditor\ShadowTexturePatternEditor.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Update="TexturePatternEditor\TexturePatternEditor.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/HeroesPowerPlant/LevelEditor/BSPRenderer.cs
+++ b/HeroesPowerPlant/LevelEditor/BSPRenderer.cs
@@ -197,6 +197,7 @@ namespace HeroesPowerPlant
                     {
                         levelEditor.initVisibilityEditor(true, fileName);
                         levelEditor.shadowSplineEditor.Init(fileName);
+                        Program.MainForm.ShadowTexturePatternEditor.OpenFile(fileName);
                     }
                     else if (fileName.Contains("fx"))
                     {

--- a/HeroesPowerPlant/LevelEditor/EditBSPName.designer.cs
+++ b/HeroesPowerPlant/LevelEditor/EditBSPName.designer.cs
@@ -28,59 +28,62 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.textBox1 = new System.Windows.Forms.TextBox();
-            this.button1 = new System.Windows.Forms.Button();
-            this.button2 = new System.Windows.Forms.Button();
-            this.SuspendLayout();
+            textBox1 = new System.Windows.Forms.TextBox();
+            button1 = new System.Windows.Forms.Button();
+            button2 = new System.Windows.Forms.Button();
+            SuspendLayout();
             // 
             // textBox1
             // 
-            this.textBox1.Location = new System.Drawing.Point(12, 12);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(156, 20);
-            this.textBox1.TabIndex = 0;
+            textBox1.Location = new System.Drawing.Point(14, 14);
+            textBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox1.Name = "textBox1";
+            textBox1.Size = new System.Drawing.Size(181, 23);
+            textBox1.TabIndex = 0;
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(93, 38);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(75, 23);
-            this.button1.TabIndex = 1;
-            this.button1.Text = "OK";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            button1.Location = new System.Drawing.Point(108, 44);
+            button1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button1.Name = "button1";
+            button1.Size = new System.Drawing.Size(88, 27);
+            button1.TabIndex = 1;
+            button1.Text = "OK";
+            button1.UseVisualStyleBackColor = true;
+            button1.Click += button1_Click;
             // 
             // button2
             // 
-            this.button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.button2.Location = new System.Drawing.Point(12, 38);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(75, 23);
-            this.button2.TabIndex = 2;
-            this.button2.Text = "Cancel";
-            this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.button2_Click);
+            button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            button2.Location = new System.Drawing.Point(14, 44);
+            button2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button2.Name = "button2";
+            button2.Size = new System.Drawing.Size(88, 27);
+            button2.TabIndex = 2;
+            button2.Text = "Cancel";
+            button2.UseVisualStyleBackColor = true;
+            button2.Click += button2_Click;
             // 
             // EditBSPName
             // 
-            this.AcceptButton = this.button1;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.button2;
-            this.ClientSize = new System.Drawing.Size(180, 73);
-            this.Controls.Add(this.button2);
-            this.Controls.Add(this.button1);
-            this.Controls.Add(this.textBox1);
-            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "EditBSPName";
-            this.ShowIcon = false;
-            this.ShowInTaskbar = false;
-            this.Text = "New BSP Name";
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AcceptButton = button1;
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            CancelButton = button2;
+            ClientSize = new System.Drawing.Size(210, 84);
+            Controls.Add(button2);
+            Controls.Add(button1);
+            Controls.Add(textBox1);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            MaximizeBox = false;
+            MinimizeBox = false;
+            Name = "EditBSPName";
+            ShowIcon = false;
+            ShowInTaskbar = false;
+            Text = "New Name";
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion

--- a/HeroesPowerPlant/LightEditor/LightMenu.cs
+++ b/HeroesPowerPlant/LightEditor/LightMenu.cs
@@ -1,5 +1,4 @@
 ﻿using HeroesPowerPlant.Shared.IO.Config;
-using HeroesPowerPlant.TexturePatternEditor;
 using Ookii.Dialogs.WinForms;
 using System;
 using System.Windows.Forms;

--- a/HeroesPowerPlant/MainForm/MainForm.Designer.cs
+++ b/HeroesPowerPlant/MainForm/MainForm.Designer.cs
@@ -95,6 +95,7 @@ namespace HeroesPowerPlant.MainForm
             statusStrip1 = new StatusStrip();
             toolStripStatusLabel1 = new ToolStripStatusLabel();
             renderPanel = new Panel();
+            shadowTexturePatternEditorToolStripMenuItem = new ToolStripMenuItem();
             menuStrip1.SuspendLayout();
             statusStrip1.SuspendLayout();
             SuspendLayout();
@@ -159,7 +160,7 @@ namespace HeroesPowerPlant.MainForm
             // 
             // editorsToolStripMenuItem
             // 
-            editorsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { modLoaderConfigEditorF2ToolStripMenuItem, levelEditorF3ToolStripMenuItem, collisionEditorToolStripMenuItem, layoutEditorToolStripMenuItem, cameraEditorToolStripMenuItem, shadowCameraEditorToolStripMenuItem, particleEditorF8ToolStripMenuItem, texturePatternEditorF9ToolStripMenuItem, lightEditorF10ToolStripMenuItem, sETIDTableEditorToolStripMenuItem, shadowLayoutDiffToolToolStripMenuItem });
+            editorsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { modLoaderConfigEditorF2ToolStripMenuItem, levelEditorF3ToolStripMenuItem, collisionEditorToolStripMenuItem, layoutEditorToolStripMenuItem, cameraEditorToolStripMenuItem, shadowCameraEditorToolStripMenuItem, particleEditorF8ToolStripMenuItem, texturePatternEditorF9ToolStripMenuItem, shadowTexturePatternEditorToolStripMenuItem, lightEditorF10ToolStripMenuItem, sETIDTableEditorToolStripMenuItem, shadowLayoutDiffToolToolStripMenuItem });
             editorsToolStripMenuItem.Name = "editorsToolStripMenuItem";
             editorsToolStripMenuItem.Size = new System.Drawing.Size(55, 20);
             editorsToolStripMenuItem.Text = "Editors";
@@ -571,6 +572,13 @@ namespace HeroesPowerPlant.MainForm
             renderPanel.MouseWheel += renderPanel_MouseWheel;
             renderPanel.Resize += ResetMouseCenter;
             // 
+            // shadowTexturePatternEditorToolStripMenuItem
+            // 
+            shadowTexturePatternEditorToolStripMenuItem.Name = "shadowTexturePatternEditorToolStripMenuItem";
+            shadowTexturePatternEditorToolStripMenuItem.Size = new System.Drawing.Size(234, 22);
+            shadowTexturePatternEditorToolStripMenuItem.Text = "Shadow Texture Pattern Editor";
+            shadowTexturePatternEditorToolStripMenuItem.Click += shadowTexturePatternEditorToolStripMenuItem_Click;
+            // 
             // MainForm
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
@@ -666,6 +674,7 @@ namespace HeroesPowerPlant.MainForm
         private ToolStripMenuItem ResourceToolStripMenuItemSetFNT;
         private ToolStripMenuItem openHeroesLevelToolStripMenuItem;
         private ToolStripSeparator toolStripSeparator2;
+        private ToolStripMenuItem shadowTexturePatternEditorToolStripMenuItem;
     }
 }
 

--- a/HeroesPowerPlant/MainForm/MainForm.cs
+++ b/HeroesPowerPlant/MainForm/MainForm.cs
@@ -25,6 +25,7 @@ namespace HeroesPowerPlant.MainForm
         public ShadowLayoutDiffTool.ShadowLayoutDiffTool ShadowLayoutDiffTool;
         public ParticleEditor.ParticleMenu ParticleEditor;
         public TexturePatternEditor.TexturePatternEditor TexturePatternEditor;
+        public ShadowTexturePatternEditor.ShadowTexturePatternEditor ShadowTexturePatternEditor;
         public LightEditor.LightMenu LightEditor;
         public SetIdTableEditor.SetIdTableEditor SetIdTableEditor;
 
@@ -58,6 +59,7 @@ namespace HeroesPowerPlant.MainForm
             ShadowLayoutDiffTool = new ShadowLayoutDiffTool.ShadowLayoutDiffTool();
             ParticleEditor = new ParticleEditor.ParticleMenu();
             TexturePatternEditor = new TexturePatternEditor.TexturePatternEditor();
+            ShadowTexturePatternEditor = new ShadowTexturePatternEditor.ShadowTexturePatternEditor();
             LightEditor = new LightEditor.LightMenu();
             SetIdTableEditor = new SetIdTableEditor.SetIdTableEditor();
 
@@ -110,7 +112,7 @@ namespace HeroesPowerPlant.MainForm
         private void ToolStripFileSaveAs(object sender, EventArgs e)
         {
             VistaSaveFileDialog openFile = new VistaSaveFileDialog()
-            { 
+            {
                 Filter = "Power Plant Config File|*.json",
                 DefaultExt = ".json"
             };
@@ -161,6 +163,7 @@ namespace HeroesPowerPlant.MainForm
             ShadowLayoutDiffTool.New();
             ParticleEditor.New();
             TexturePatternEditor.New();
+            ShadowTexturePatternEditor.New();
             SetIdTableEditor.New();
             LightEditor.New();
             renderer.dffRenderer.ClearObjectONEFiles();
@@ -412,6 +415,13 @@ namespace HeroesPowerPlant.MainForm
             TexturePatternEditor.WindowState = FormWindowState.Normal;
         }
 
+        private void shadowTexturePatternEditorToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            ShadowTexturePatternEditor.Show();
+            ShadowTexturePatternEditor.Focus();
+            ShadowTexturePatternEditor.WindowState = FormWindowState.Normal;
+        }
+
         private void sETIDTableEditorToolStripMenuItem_Click(object sender, EventArgs e)
         {
             SetIdTableEditor.Show();
@@ -576,8 +586,8 @@ namespace HeroesPowerPlant.MainForm
                 (Path.Combine(fileName, fileNamePrefix) + "_nrm.dat", true),
                 (Path.Combine(fileName, fileNamePrefix) + "_hrd.dat", true)
             })
-            if (File.Exists(s.Item1))
-                AddLayoutEditor(s.Item1, false, s.Item2);
+                if (File.Exists(s.Item1))
+                    AddLayoutEditor(s.Item1, false, s.Item2);
             foreach (var l in LayoutEditors) // reset selected index to prevent F5 not opening all if initial without object click
                 l.SetSelectedIndex(-1, false);
 
@@ -1019,10 +1029,11 @@ namespace HeroesPowerPlant.MainForm
             ShadowCameraEditor,
             ParticleEditor,
             TexturePatternEditor,
+            ShadowTexturePatternEditor,
             LightEditor,
             SetIdTableEditor,
         };
-        
+
         private void MainForm_FormClosing(object sender, FormClosingEventArgs e)
         {
             var unsavedChanges = this.unsavedChanges;
@@ -1171,7 +1182,8 @@ namespace HeroesPowerPlant.MainForm
                     if (fileName.ToLower().EndsWith(".one"))
                     {
                         TextureManager.LoadTexturesFromTXD(fileName, renderer, LevelEditor.bspRenderer);
-                    } else
+                    }
+                    else
                     {
                         TextureManager.SetupTextureDisplay(File.ReadAllBytes(fileName), renderer, LevelEditor.bspRenderer);
                     }
@@ -1218,6 +1230,7 @@ namespace HeroesPowerPlant.MainForm
             ShadowCameraEditor.TopMost = value;
             ParticleEditor.TopMost = value;
             TexturePatternEditor.TopMost = value;
+            ShadowTexturePatternEditor.TopMost = value;
             SetIdTableEditor.TopMost = value;
             LightEditor.TopMost = value;
             ShadowLayoutDiffTool.TopMost = value;
@@ -1303,7 +1316,7 @@ namespace HeroesPowerPlant.MainForm
             SetMaxFPS();
         }
 
-        public void SetWindowPriorityBehavior (bool isEnabled)
+        public void SetWindowPriorityBehavior(bool isEnabled)
         {
             LegacyWindowPriorityBehavior_ToolStripMenuItem.Checked = isEnabled;
         }

--- a/HeroesPowerPlant/MainForm/MainForm.resx
+++ b/HeroesPowerPlant/MainForm/MainForm.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter

--- a/HeroesPowerPlant/ShadowTexturePatternEditor/ShadowPatternEntry.cs
+++ b/HeroesPowerPlant/ShadowTexturePatternEditor/ShadowPatternEntry.cs
@@ -1,0 +1,90 @@
+﻿using System.Collections.Generic;
+
+namespace HeroesPowerPlant.ShadowTexturePatternEditor
+{
+    public struct ShadowTexturePatternFrame
+    {
+        public uint FrameOffset;
+        public uint TextureNumber;
+
+        public ShadowTexturePatternFrame(ShadowTexturePatternFrame f)
+        {
+            FrameOffset = f.FrameOffset;
+            TextureNumber = f.TextureNumber;
+        }
+
+        public override string ToString()
+        {
+            return $"[{FrameOffset} : {TextureNumber}]";
+        }
+    }
+
+    public class ShadowPatternEntry
+    {
+        public string FileName;
+        public uint FrameCount;
+        public string TextureName;
+        public string AnimationName;
+        public uint UnknownInt;
+        public uint KeyframeCount { get => (uint)frames.Count; }
+        public List<ShadowTexturePatternFrame> frames;
+
+        public ShadowPatternEntry()
+        {
+            FileName = "default.adb";
+            TextureName = "default";
+            AnimationName = "default";
+            frames = new List<ShadowTexturePatternFrame>();
+        }
+
+        public ShadowPatternEntry(ShadowPatternEntry p)
+        {
+            FileName = p.FileName;
+            FrameCount = p.FrameCount;
+            TextureName = p.TextureName;
+            AnimationName = p.AnimationName;
+            UnknownInt = p.UnknownInt;
+
+            frames = new List<ShadowTexturePatternFrame>();
+            foreach (ShadowTexturePatternFrame f in p.frames)
+                frames.Add(new ShadowTexturePatternFrame(f));
+        }
+
+        public override string ToString()
+        {
+            return $"{FileName} [{FrameCount}]";
+        }
+
+        // Rendering
+        private uint counter = 0;
+        public bool isSelected;
+
+        public void Animate(ShadowTexturePatternEditor editor, BSPRenderer bspRenderer, DFFRenderer dffRenderer)
+        {
+            if (FrameCount == 0)
+                return;
+
+            counter++;
+            counter = counter % FrameCount;
+
+            for (int i = 0; i < frames.Count; i++)
+                if (frames[i].FrameOffset == counter)
+                {
+                    string newTextureName = AnimationName + "." + frames[i].TextureNumber;
+                    if (TextureManager.HasTexture(newTextureName))
+                        TextureManager.SetTextureForAnimation(TextureName, newTextureName, bspRenderer, dffRenderer);
+                }
+
+            if (isSelected)
+                editor.SendPlaying(counter);
+        }
+
+        public void StopAnimation(BSPRenderer bspRenderer, DFFRenderer dffRenderer)
+        {
+            counter = 0;
+
+            if (TextureManager.HasTexture(TextureName))
+                TextureManager.SetTextureForAnimation(TextureName, TextureName, bspRenderer, dffRenderer);
+        }
+    }
+}

--- a/HeroesPowerPlant/ShadowTexturePatternEditor/ShadowPatternSystem.cs
+++ b/HeroesPowerPlant/ShadowTexturePatternEditor/ShadowPatternSystem.cs
@@ -1,0 +1,253 @@
+﻿using HeroesONE_R.Structures;
+using HeroesONE_R.Structures.Subsctructures;
+using HeroesPowerPlant.Shared.Utilities;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace HeroesPowerPlant.ShadowTexturePatternEditor
+{
+    public class ShadowPatternSystem
+    {
+        public bool UnsavedChanges { get; set; } = false;
+
+        private string currentlyOpenONE;
+        public string CurrentlyOpenONE
+        {
+            get => currentlyOpenONE;
+            private set => currentlyOpenONE = value;
+        }
+
+        private Archive shadowDATONE;
+
+        public List<ShadowPatternEntry> patterns;
+
+        public ShadowPatternSystem()
+        {
+            patterns = new List<ShadowPatternEntry>();
+            UnsavedChanges = false;
+        }
+
+        public ShadowPatternSystem(string fileName)
+        {
+            if (!File.Exists(fileName))
+            {
+                return;
+            }
+            byte[] fileContents = File.ReadAllBytes(fileName);
+            shadowDATONE = Archive.FromONEFile(ref fileContents);
+            EndianBinaryReader splineReader = null;
+
+            patterns = new List<ShadowPatternEntry>();
+            currentlyOpenONE = fileName;
+
+            foreach (var file in shadowDATONE.Files)
+            {
+                if (file.Name.EndsWith(".ADB"))
+                {
+                    using var patternReader = new EndianBinaryReader(new MemoryStream(file.DecompressThis()), Endianness.Little);
+                    uint frameCount = patternReader.ReadUInt32();
+
+                    string textureName = new string(patternReader.ReadChars(0x20)).Trim('\0');
+                    string animationName = new string(patternReader.ReadChars(0x20)).Trim('\0');
+
+                    uint unknownInt = patternReader.ReadUInt32();
+                    uint keyframeCount = patternReader.ReadUInt32(); // we throw this away since we calculate it ourselves on save
+
+                    List<ShadowTexturePatternFrame> frames = new List<ShadowTexturePatternFrame>();
+
+                    uint FrameOffset = patternReader.ReadUInt32();
+                    uint TextureNumber = patternReader.ReadUInt32();
+
+                    while (patternReader.BaseStream.Position < patternReader.BaseStream.Length) // could also count up to keyframeCount
+                    {
+                        frames.Add(new ShadowTexturePatternFrame()
+                        {
+                            FrameOffset = FrameOffset,
+                            TextureNumber = TextureNumber
+                        });
+
+                        FrameOffset = patternReader.ReadUInt32();
+                        TextureNumber = patternReader.ReadUInt32();
+                    }
+
+                    frames.Add(new ShadowTexturePatternFrame()
+                    {
+                        FrameOffset = FrameOffset,
+                        TextureNumber = TextureNumber
+                    });
+
+                    patterns.Add(new ShadowPatternEntry()
+                    {
+                        FileName = file.Name,
+                        UnknownInt = unknownInt,
+                        FrameCount = frameCount,
+                        TextureName = textureName,
+                        AnimationName = animationName,
+                        frames = frames
+                    });
+                }
+            }
+            UnsavedChanges = false;
+        }
+
+        public void Save(string fileName)
+        {
+            currentlyOpenONE = fileName;
+            Save();
+        }
+
+        public void Save()
+        {
+            if (shadowDATONE == null)
+            {
+                shadowDATONE = new Archive(CommonRWVersions.Shadow050);
+            }
+
+            foreach (ShadowPatternEntry p in patterns) 
+            {
+                List<byte> adbBytes = new List<byte>();
+
+                adbBytes.AddRange(BitConverter.GetBytes(p.FrameCount));
+                foreach (char c in p.TextureName)
+                    adbBytes.Add((byte)c);
+                for (int i = p.TextureName.Length; i < 0x20; i++)
+                    adbBytes.Add((byte)0);
+                foreach (char c in p.AnimationName)
+                    adbBytes.Add((byte)c);
+                for (int i = p.AnimationName.Length; i < 0x20; i++)
+                    adbBytes.Add((byte)0);
+                adbBytes.AddRange(BitConverter.GetBytes(p.UnknownInt));
+                adbBytes.AddRange(BitConverter.GetBytes(p.KeyframeCount));
+
+                foreach (ShadowTexturePatternFrame f in p.frames)
+                {
+                    adbBytes.AddRange(BitConverter.GetBytes(f.FrameOffset));
+                    adbBytes.AddRange(BitConverter.GetBytes(f.TextureNumber));
+                }
+
+                var adbOutput = adbBytes.ToArray();
+
+                // if this ADB already exists in the .ONE...
+                bool foundFile = false;
+                foreach (var fileInDat in shadowDATONE.Files)
+                {
+                    if (fileInDat.Name == p.FileName)
+                    {
+                        fileInDat.CompressedData = Prs.Compress(ref adbOutput);
+                        foundFile = true;
+                        break;
+                    }
+                }
+
+                // if we already stored the file, on to the next
+                if (foundFile)
+                {
+                    continue;
+                }
+
+                // add as a new file in the .ONE in the case the ADB was not found
+                ArchiveFile file = new ArchiveFile(p.FileName, adbBytes.ToArray());
+                shadowDATONE.Files.Add(file);
+            }
+
+            // lastly remove any ADBs that were not in the list, since we are not actively keeping track (optimize later?)
+            for (int i = 0; i < shadowDATONE.Files.Count; i++)
+            {
+                if (!shadowDATONE.Files[i].Name.EndsWith(".ADB"))
+                {
+                    continue;
+                }
+                bool exit = false;
+                foreach (ShadowPatternEntry p in patterns)
+                {
+                    if (p.FileName == shadowDATONE.Files[i].Name)
+                    {
+                        exit = true;
+                        break; // if we found the current entry in both lists, skip it
+                    }
+                }
+                if (!exit)
+                {
+                    // if we've reached this point, this file needs to be removed
+                    shadowDATONE.Files.RemoveAt(i);
+                }
+            }
+
+            File.WriteAllBytes(currentlyOpenONE, shadowDATONE.BuildShadowONEArchive(true).ToArray());
+            UnsavedChanges = false;
+        }
+
+        public IEnumerable<string> GetPatternEntries()
+        {
+            List<String> list = new List<string>();
+            foreach (ShadowPatternEntry p in patterns)
+                list.Add(p.ToString());
+            return list;
+        }
+
+        public int GetPatternCount()
+        {
+            return patterns.Count;
+        }
+
+        public ShadowPatternEntry GetPatternAt(int index)
+        {
+            if (index >= 0 & index < patterns.Count)
+                return patterns[index];
+            throw new IndexOutOfRangeException();
+        }
+
+        public string Add()
+        {
+            ShadowPatternEntry p = new ShadowPatternEntry();
+            patterns.Add(p);
+            UnsavedChanges = true;
+            return p.ToString();
+        }
+
+        public string Add(int index)
+        {
+            ShadowPatternEntry p = new ShadowPatternEntry(patterns[index]);
+            patterns.Add(p);
+            UnsavedChanges = true;
+            return p.ToString();
+        }
+
+        public int Remove(int index)
+        {
+            if (index >= 0 & index < patterns.Count)
+            {
+                patterns[index].StopAnimation(Program.MainForm.LevelEditor.bspRenderer, Program.MainForm.renderer.dffRenderer);
+                patterns.RemoveAt(index);
+                UnsavedChanges = true;
+                return index;
+            }
+            throw new IndexOutOfRangeException();
+        }
+
+        public void Deselect()
+        {
+            foreach (ShadowPatternEntry p in patterns)
+                p.isSelected = false;
+        }
+
+        // Rendering
+
+        private bool switcher = true;
+
+        public void Animate(ShadowTexturePatternEditor editor)
+        {
+            if (switcher)
+                foreach (ShadowPatternEntry p in patterns)
+                    p.Animate(editor, Program.MainForm.LevelEditor.bspRenderer, Program.MainForm.renderer.dffRenderer);
+            switcher = !switcher;
+        }
+
+        public void StopAnimation()
+        {
+            foreach (ShadowPatternEntry p in patterns)
+                p.StopAnimation(Program.MainForm.LevelEditor.bspRenderer, Program.MainForm.renderer.dffRenderer);
+        }
+    }
+}

--- a/HeroesPowerPlant/ShadowTexturePatternEditor/ShadowTexturePatternEditor.Designer.cs
+++ b/HeroesPowerPlant/ShadowTexturePatternEditor/ShadowTexturePatternEditor.Designer.cs
@@ -1,0 +1,446 @@
+﻿namespace HeroesPowerPlant.ShadowTexturePatternEditor
+{
+    partial class ShadowTexturePatternEditor
+    {
+        /// <summary>
+        /// Required designer variable.
+        /// </summary>
+        private System.ComponentModel.IContainer components = null;
+
+        /// <summary>
+        /// Clean up any resources being used.
+        /// </summary>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            menuStrip1 = new System.Windows.Forms.MenuStrip();
+            fileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            newToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            openToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            saveToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            saveAsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            buttonAdd = new System.Windows.Forms.Button();
+            buttonCopy = new System.Windows.Forms.Button();
+            buttonRemove = new System.Windows.Forms.Button();
+            statusStrip1 = new System.Windows.Forms.StatusStrip();
+            toolStripStatusLabel1 = new System.Windows.Forms.ToolStripStatusLabel();
+            listBoxPatterns = new System.Windows.Forms.ListBox();
+            groupBox1 = new System.Windows.Forms.GroupBox();
+            groupBox2 = new System.Windows.Forms.GroupBox();
+            textBoxTextureName = new System.Windows.Forms.TextBox();
+            groupBox3 = new System.Windows.Forms.GroupBox();
+            textBoxAnimationName = new System.Windows.Forms.TextBox();
+            groupBox4 = new System.Windows.Forms.GroupBox();
+            numericFrameCount = new System.Windows.Forms.NumericUpDown();
+            groupBox5 = new System.Windows.Forms.GroupBox();
+            labelFrame = new System.Windows.Forms.Label();
+            buttonPlay = new System.Windows.Forms.Button();
+            groupBox7 = new System.Windows.Forms.GroupBox();
+            numericTextureNumber = new System.Windows.Forms.NumericUpDown();
+            groupBox6 = new System.Windows.Forms.GroupBox();
+            numericFrameOffset = new System.Windows.Forms.NumericUpDown();
+            listBoxFrames = new System.Windows.Forms.ListBox();
+            buttonAddFrame = new System.Windows.Forms.Button();
+            button3 = new System.Windows.Forms.Button();
+            menuStrip1.SuspendLayout();
+            statusStrip1.SuspendLayout();
+            groupBox1.SuspendLayout();
+            groupBox2.SuspendLayout();
+            groupBox3.SuspendLayout();
+            groupBox4.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)numericFrameCount).BeginInit();
+            groupBox5.SuspendLayout();
+            groupBox7.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)numericTextureNumber).BeginInit();
+            groupBox6.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)numericFrameOffset).BeginInit();
+            SuspendLayout();
+            // 
+            // menuStrip1
+            // 
+            menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { fileToolStripMenuItem });
+            menuStrip1.Location = new System.Drawing.Point(0, 0);
+            menuStrip1.Name = "menuStrip1";
+            menuStrip1.Padding = new System.Windows.Forms.Padding(7, 2, 0, 2);
+            menuStrip1.Size = new System.Drawing.Size(464, 24);
+            menuStrip1.TabIndex = 0;
+            menuStrip1.Text = "menuStrip1";
+            // 
+            // fileToolStripMenuItem
+            // 
+            fileToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { newToolStripMenuItem, openToolStripMenuItem, saveToolStripMenuItem, saveAsToolStripMenuItem });
+            fileToolStripMenuItem.Name = "fileToolStripMenuItem";
+            fileToolStripMenuItem.Size = new System.Drawing.Size(37, 20);
+            fileToolStripMenuItem.Text = "File";
+            // 
+            // newToolStripMenuItem
+            // 
+            newToolStripMenuItem.Name = "newToolStripMenuItem";
+            newToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
+            newToolStripMenuItem.Text = "New";
+            newToolStripMenuItem.Click += newToolStripMenuItem_Click;
+            // 
+            // openToolStripMenuItem
+            // 
+            openToolStripMenuItem.Name = "openToolStripMenuItem";
+            openToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
+            openToolStripMenuItem.Text = "Open...";
+            openToolStripMenuItem.Click += openToolStripMenuItem_Click;
+            // 
+            // saveToolStripMenuItem
+            // 
+            saveToolStripMenuItem.Name = "saveToolStripMenuItem";
+            saveToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
+            saveToolStripMenuItem.Text = "Save";
+            saveToolStripMenuItem.Click += saveToolStripMenuItem_Click;
+            // 
+            // saveAsToolStripMenuItem
+            // 
+            saveAsToolStripMenuItem.Name = "saveAsToolStripMenuItem";
+            saveAsToolStripMenuItem.Size = new System.Drawing.Size(123, 22);
+            saveAsToolStripMenuItem.Text = "Save As...";
+            saveAsToolStripMenuItem.Click += saveAsToolStripMenuItem_Click;
+            // 
+            // buttonAdd
+            // 
+            buttonAdd.Location = new System.Drawing.Point(7, 348);
+            buttonAdd.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            buttonAdd.Name = "buttonAdd";
+            buttonAdd.Size = new System.Drawing.Size(48, 27);
+            buttonAdd.TabIndex = 2;
+            buttonAdd.Text = "Add";
+            buttonAdd.UseVisualStyleBackColor = true;
+            buttonAdd.Click += buttonAdd_Click;
+            // 
+            // buttonCopy
+            // 
+            buttonCopy.Location = new System.Drawing.Point(62, 348);
+            buttonCopy.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            buttonCopy.Name = "buttonCopy";
+            buttonCopy.Size = new System.Drawing.Size(50, 27);
+            buttonCopy.TabIndex = 3;
+            buttonCopy.Text = "Copy";
+            buttonCopy.UseVisualStyleBackColor = true;
+            buttonCopy.Click += buttonCopy_Click;
+            // 
+            // buttonRemove
+            // 
+            buttonRemove.Location = new System.Drawing.Point(119, 348);
+            buttonRemove.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            buttonRemove.Name = "buttonRemove";
+            buttonRemove.Size = new System.Drawing.Size(75, 27);
+            buttonRemove.TabIndex = 4;
+            buttonRemove.Text = "Remove";
+            buttonRemove.UseVisualStyleBackColor = true;
+            buttonRemove.Click += buttonRemove_Click;
+            // 
+            // statusStrip1
+            // 
+            statusStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { toolStripStatusLabel1 });
+            statusStrip1.Location = new System.Drawing.Point(0, 421);
+            statusStrip1.Name = "statusStrip1";
+            statusStrip1.Padding = new System.Windows.Forms.Padding(1, 0, 16, 0);
+            statusStrip1.Size = new System.Drawing.Size(464, 22);
+            statusStrip1.TabIndex = 6;
+            statusStrip1.Text = "statusStrip1";
+            // 
+            // toolStripStatusLabel1
+            // 
+            toolStripStatusLabel1.Name = "toolStripStatusLabel1";
+            toolStripStatusLabel1.Size = new System.Drawing.Size(81, 17);
+            toolStripStatusLabel1.Text = "No file loaded";
+            // 
+            // listBoxPatterns
+            // 
+            listBoxPatterns.FormattingEnabled = true;
+            listBoxPatterns.ItemHeight = 15;
+            listBoxPatterns.Location = new System.Drawing.Point(7, 22);
+            listBoxPatterns.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            listBoxPatterns.Name = "listBoxPatterns";
+            listBoxPatterns.Size = new System.Drawing.Size(186, 319);
+            listBoxPatterns.TabIndex = 7;
+            listBoxPatterns.SelectedIndexChanged += listBoxPatterns_SelectedIndexChanged;
+            listBoxPatterns.DoubleClick += listBoxPatterns_DoubleClick;
+            // 
+            // groupBox1
+            // 
+            groupBox1.Controls.Add(listBoxPatterns);
+            groupBox1.Controls.Add(buttonAdd);
+            groupBox1.Controls.Add(buttonCopy);
+            groupBox1.Controls.Add(buttonRemove);
+            groupBox1.Location = new System.Drawing.Point(14, 31);
+            groupBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox1.Name = "groupBox1";
+            groupBox1.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox1.Size = new System.Drawing.Size(202, 381);
+            groupBox1.TabIndex = 8;
+            groupBox1.TabStop = false;
+            groupBox1.Text = "Texture Patterns";
+            // 
+            // groupBox2
+            // 
+            groupBox2.Controls.Add(textBoxTextureName);
+            groupBox2.Location = new System.Drawing.Point(223, 31);
+            groupBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox2.Name = "groupBox2";
+            groupBox2.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox2.Size = new System.Drawing.Size(233, 53);
+            groupBox2.TabIndex = 9;
+            groupBox2.TabStop = false;
+            groupBox2.Text = "Texture Name";
+            // 
+            // textBoxTextureName
+            // 
+            textBoxTextureName.Location = new System.Drawing.Point(7, 22);
+            textBoxTextureName.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBoxTextureName.Name = "textBoxTextureName";
+            textBoxTextureName.Size = new System.Drawing.Size(219, 23);
+            textBoxTextureName.TabIndex = 10;
+            textBoxTextureName.TextChanged += textBoxTextureName_TextChanged;
+            // 
+            // groupBox3
+            // 
+            groupBox3.Controls.Add(textBoxAnimationName);
+            groupBox3.Location = new System.Drawing.Point(223, 91);
+            groupBox3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox3.Name = "groupBox3";
+            groupBox3.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox3.Size = new System.Drawing.Size(233, 53);
+            groupBox3.TabIndex = 11;
+            groupBox3.TabStop = false;
+            groupBox3.Text = "Animation Name";
+            // 
+            // textBoxAnimationName
+            // 
+            textBoxAnimationName.Location = new System.Drawing.Point(7, 22);
+            textBoxAnimationName.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBoxAnimationName.Name = "textBoxAnimationName";
+            textBoxAnimationName.Size = new System.Drawing.Size(219, 23);
+            textBoxAnimationName.TabIndex = 10;
+            textBoxAnimationName.TextChanged += textBoxAnimationName_TextChanged;
+            // 
+            // groupBox4
+            // 
+            groupBox4.Controls.Add(numericFrameCount);
+            groupBox4.Location = new System.Drawing.Point(223, 151);
+            groupBox4.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox4.Name = "groupBox4";
+            groupBox4.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox4.Size = new System.Drawing.Size(233, 53);
+            groupBox4.TabIndex = 12;
+            groupBox4.TabStop = false;
+            groupBox4.Text = "Frame Count";
+            // 
+            // numericFrameCount
+            // 
+            numericFrameCount.Location = new System.Drawing.Point(7, 22);
+            numericFrameCount.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericFrameCount.Name = "numericFrameCount";
+            numericFrameCount.Size = new System.Drawing.Size(219, 23);
+            numericFrameCount.TabIndex = 13;
+            numericFrameCount.ValueChanged += numericFrameCount_ValueChanged;
+            // 
+            // groupBox5
+            // 
+            groupBox5.Controls.Add(labelFrame);
+            groupBox5.Controls.Add(buttonPlay);
+            groupBox5.Controls.Add(groupBox7);
+            groupBox5.Controls.Add(groupBox6);
+            groupBox5.Controls.Add(listBoxFrames);
+            groupBox5.Controls.Add(buttonAddFrame);
+            groupBox5.Controls.Add(button3);
+            groupBox5.Location = new System.Drawing.Point(223, 211);
+            groupBox5.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox5.Name = "groupBox5";
+            groupBox5.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox5.Size = new System.Drawing.Size(233, 201);
+            groupBox5.TabIndex = 9;
+            groupBox5.TabStop = false;
+            groupBox5.Text = "Keyframes";
+            // 
+            // labelFrame
+            // 
+            labelFrame.AutoSize = true;
+            labelFrame.Location = new System.Drawing.Point(120, 147);
+            labelFrame.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            labelFrame.Name = "labelFrame";
+            labelFrame.Size = new System.Drawing.Size(51, 15);
+            labelFrame.TabIndex = 17;
+            labelFrame.Text = "Stopped";
+            // 
+            // buttonPlay
+            // 
+            buttonPlay.Location = new System.Drawing.Point(120, 168);
+            buttonPlay.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            buttonPlay.Name = "buttonPlay";
+            buttonPlay.Size = new System.Drawing.Size(106, 27);
+            buttonPlay.TabIndex = 16;
+            buttonPlay.Text = "Play";
+            buttonPlay.UseVisualStyleBackColor = true;
+            buttonPlay.Click += buttonPlay_Click;
+            // 
+            // groupBox7
+            // 
+            groupBox7.Controls.Add(numericTextureNumber);
+            groupBox7.Location = new System.Drawing.Point(120, 83);
+            groupBox7.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox7.Name = "groupBox7";
+            groupBox7.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox7.Size = new System.Drawing.Size(106, 54);
+            groupBox7.TabIndex = 15;
+            groupBox7.TabStop = false;
+            groupBox7.Text = "Texture Num";
+            // 
+            // numericTextureNumber
+            // 
+            numericTextureNumber.Location = new System.Drawing.Point(7, 22);
+            numericTextureNumber.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericTextureNumber.Name = "numericTextureNumber";
+            numericTextureNumber.Size = new System.Drawing.Size(92, 23);
+            numericTextureNumber.TabIndex = 14;
+            numericTextureNumber.ValueChanged += numericTextureNumber_ValueChanged;
+            // 
+            // groupBox6
+            // 
+            groupBox6.Controls.Add(numericFrameOffset);
+            groupBox6.Location = new System.Drawing.Point(120, 22);
+            groupBox6.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox6.Name = "groupBox6";
+            groupBox6.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox6.Size = new System.Drawing.Size(106, 54);
+            groupBox6.TabIndex = 11;
+            groupBox6.TabStop = false;
+            groupBox6.Text = "Frame Offset";
+            // 
+            // numericFrameOffset
+            // 
+            numericFrameOffset.Location = new System.Drawing.Point(7, 22);
+            numericFrameOffset.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericFrameOffset.Name = "numericFrameOffset";
+            numericFrameOffset.Size = new System.Drawing.Size(92, 23);
+            numericFrameOffset.TabIndex = 14;
+            numericFrameOffset.ValueChanged += numericFrameOffset_ValueChanged;
+            // 
+            // listBoxFrames
+            // 
+            listBoxFrames.FormattingEnabled = true;
+            listBoxFrames.ItemHeight = 15;
+            listBoxFrames.Location = new System.Drawing.Point(7, 22);
+            listBoxFrames.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            listBoxFrames.Name = "listBoxFrames";
+            listBoxFrames.Size = new System.Drawing.Size(106, 139);
+            listBoxFrames.TabIndex = 7;
+            listBoxFrames.SelectedIndexChanged += listBoxFrames_SelectedIndexChanged;
+            // 
+            // buttonAddFrame
+            // 
+            buttonAddFrame.Location = new System.Drawing.Point(7, 168);
+            buttonAddFrame.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            buttonAddFrame.Name = "buttonAddFrame";
+            buttonAddFrame.Size = new System.Drawing.Size(42, 27);
+            buttonAddFrame.TabIndex = 2;
+            buttonAddFrame.Text = "Add";
+            buttonAddFrame.UseVisualStyleBackColor = true;
+            buttonAddFrame.Click += buttonAddFrame_Click;
+            // 
+            // button3
+            // 
+            button3.Location = new System.Drawing.Point(49, 168);
+            button3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button3.Name = "button3";
+            button3.Size = new System.Drawing.Size(64, 27);
+            button3.TabIndex = 4;
+            button3.Text = "Remove";
+            button3.UseVisualStyleBackColor = true;
+            button3.Click += buttonRemoveFrame_Click;
+            // 
+            // ShadowTexturePatternEditor
+            // 
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(464, 443);
+            Controls.Add(groupBox5);
+            Controls.Add(groupBox4);
+            Controls.Add(groupBox3);
+            Controls.Add(groupBox2);
+            Controls.Add(groupBox1);
+            Controls.Add(statusStrip1);
+            Controls.Add(menuStrip1);
+            FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            MainMenuStrip = menuStrip1;
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            MaximizeBox = false;
+            Name = "ShadowTexturePatternEditor";
+            ShowIcon = false;
+            Text = "Shadow Texture Pattern Editor";
+            FormClosing += ShadowTexturePatternEditor_FormClosing;
+            Load += ShadowTexturePatternEditor_Load;
+            menuStrip1.ResumeLayout(false);
+            menuStrip1.PerformLayout();
+            statusStrip1.ResumeLayout(false);
+            statusStrip1.PerformLayout();
+            groupBox1.ResumeLayout(false);
+            groupBox2.ResumeLayout(false);
+            groupBox2.PerformLayout();
+            groupBox3.ResumeLayout(false);
+            groupBox3.PerformLayout();
+            groupBox4.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)numericFrameCount).EndInit();
+            groupBox5.ResumeLayout(false);
+            groupBox5.PerformLayout();
+            groupBox7.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)numericTextureNumber).EndInit();
+            groupBox6.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)numericFrameOffset).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
+        }
+
+        #endregion
+
+        private System.Windows.Forms.MenuStrip menuStrip1;
+        private System.Windows.Forms.ToolStripMenuItem fileToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem newToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem openToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem saveAsToolStripMenuItem;
+        private System.Windows.Forms.Button buttonAdd;
+        private System.Windows.Forms.Button buttonCopy;
+        private System.Windows.Forms.Button buttonRemove;
+        private System.Windows.Forms.StatusStrip statusStrip1;
+        private System.Windows.Forms.ToolStripStatusLabel toolStripStatusLabel1;
+        private System.Windows.Forms.ListBox listBoxPatterns;
+        private System.Windows.Forms.GroupBox groupBox1;
+        private System.Windows.Forms.GroupBox groupBox2;
+        private System.Windows.Forms.TextBox textBoxTextureName;
+        private System.Windows.Forms.GroupBox groupBox3;
+        private System.Windows.Forms.TextBox textBoxAnimationName;
+        private System.Windows.Forms.GroupBox groupBox4;
+        private System.Windows.Forms.NumericUpDown numericFrameCount;
+        private System.Windows.Forms.GroupBox groupBox5;
+        private System.Windows.Forms.ListBox listBoxFrames;
+        private System.Windows.Forms.Button buttonAddFrame;
+        private System.Windows.Forms.Button button3;
+        private System.Windows.Forms.GroupBox groupBox7;
+        private System.Windows.Forms.NumericUpDown numericTextureNumber;
+        private System.Windows.Forms.GroupBox groupBox6;
+        private System.Windows.Forms.NumericUpDown numericFrameOffset;
+        private System.Windows.Forms.Button buttonPlay;
+        private System.Windows.Forms.Label labelFrame;
+    }
+}

--- a/HeroesPowerPlant/ShadowTexturePatternEditor/ShadowTexturePatternEditor.cs
+++ b/HeroesPowerPlant/ShadowTexturePatternEditor/ShadowTexturePatternEditor.cs
@@ -1,0 +1,371 @@
+﻿using HeroesPowerPlant.LevelEditor;
+using HeroesPowerPlant.Shared.IO.Config;
+using Ookii.Dialogs.WinForms;
+using System;
+using System.Windows.Forms;
+
+namespace HeroesPowerPlant.ShadowTexturePatternEditor
+{
+    public partial class ShadowTexturePatternEditor : Form, IUnsavedChanges
+    {
+        public ShadowTexturePatternEditor()
+        {
+            InitializeComponent();
+            numericFrameCount.Maximum = decimal.MaxValue;
+            numericFrameOffset.Maximum = decimal.MaxValue;
+            numericTextureNumber.Maximum = decimal.MaxValue;
+
+            patternSystem = new ShadowPatternSystem();
+        }
+
+        private void ShadowTexturePatternEditor_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            if (e.CloseReason == CloseReason.WindowsShutDown)
+                return;
+            if (e.CloseReason == CloseReason.FormOwnerClosing)
+                return;
+
+            e.Cancel = true;
+            Hide();
+        }
+
+        private bool programIsChangingStuff = false;
+
+        private ShadowPatternSystem patternSystem;
+
+        public bool UnsavedChanges
+        {
+            get => patternSystem.UnsavedChanges;
+            set => patternSystem.UnsavedChanges = value;
+        }
+
+        private void newToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (UnsavedChanges)
+            {
+                var result = Extensions.UnsavedChangesMessageBox(Text);
+                if (result == DialogResult.Yes)
+                {
+                    saveToolStripMenuItem_Click(sender, e);
+                    if (UnsavedChanges)
+                        return;
+                }
+                else if (result == DialogResult.Cancel)
+                    return;
+            }
+
+            New();
+        }
+
+        public void New()
+        {
+            toolStripStatusLabel1.Text = "No file loaded";
+            patternSystem = new ShadowPatternSystem();
+            listBoxPatterns.Items.Clear();
+        }
+
+        private void openToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (UnsavedChanges)
+            {
+                var result = Extensions.UnsavedChangesMessageBox(Text);
+                if (result == DialogResult.Yes)
+                {
+                    saveToolStripMenuItem_Click(sender, e);
+                    if (UnsavedChanges)
+                        return;
+                }
+                else if (result == DialogResult.Cancel)
+                    return;
+            }
+
+            VistaOpenFileDialog openFile = new VistaOpenFileDialog()
+            {
+                Filter = "ONE Files|*.one"
+            };
+
+            if (openFile.ShowDialog() == DialogResult.OK)
+                OpenFile(openFile.FileName);
+        }
+
+        public void Save()
+        {
+            saveToolStripMenuItem_Click(null, null);
+        }
+
+        private void saveToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            if (String.IsNullOrEmpty(patternSystem.CurrentlyOpenONE))
+                saveAsToolStripMenuItem_Click(sender, e);
+            else
+                patternSystem.Save();
+        }
+
+        private void saveAsToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            VistaSaveFileDialog saveFile = new VistaSaveFileDialog()
+            {
+                Filter = "ONE Files|*.one",
+                DefaultExt = ".one",
+                FileName = patternSystem.CurrentlyOpenONE
+            };
+
+            if (saveFile.ShowDialog() == DialogResult.OK)
+            {
+                patternSystem.Save(saveFile.FileName);
+                toolStripStatusLabel1.Text = patternSystem.CurrentlyOpenONE;
+            }
+        }
+
+        public void OpenFile(string fileName)
+        {
+            patternSystem = new ShadowPatternSystem(fileName);
+
+            listBoxPatterns.Items.Clear();
+            foreach (string p in patternSystem.GetPatternEntries())
+                listBoxPatterns.Items.Add(p);
+
+            listBoxFrames.Items.Clear();
+
+            toolStripStatusLabel1.Text = patternSystem.CurrentlyOpenONE;
+        }
+
+        public string GetCurrentlyOpenONE()
+        {
+            return patternSystem.CurrentlyOpenONE;
+        }
+
+        private void buttonAdd_Click(object sender, EventArgs e)
+        {
+            listBoxPatterns.Items.Add(patternSystem.Add());
+            UnsavedChanges = true;
+        }
+
+        private void buttonCopy_Click(object sender, EventArgs e)
+        {
+            if (listBoxPatterns.SelectedItem != null)
+            {
+                listBoxPatterns.Items.Add(patternSystem.Add(listBoxPatterns.SelectedIndex));
+                UnsavedChanges = true;
+            }
+        }
+
+        private void buttonRemove_Click(object sender, EventArgs e)
+        {
+            if (listBoxPatterns.SelectedItem != null)
+            {
+                programIsChangingStuff = true;
+                listBoxPatterns.Items.RemoveAt(patternSystem.Remove(listBoxPatterns.SelectedIndex));
+                UnsavedChanges = true;
+                programIsChangingStuff = false;
+            }
+        }
+
+        private void listBoxPatterns_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (programIsChangingStuff | listBoxPatterns.SelectedItem == null)
+                return;
+
+            programIsChangingStuff = true;
+
+            patternSystem.Deselect();
+
+            ShadowPatternEntry selected = patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex);
+            selected.isSelected = true;
+
+            textBoxTextureName.Text = selected.TextureName;
+            textBoxAnimationName.Text = selected.AnimationName;
+            numericFrameCount.Value = selected.FrameCount;
+
+            listBoxFrames.Items.Clear();
+
+            foreach (ShadowTexturePatternFrame f in selected.frames)
+                listBoxFrames.Items.Add(f.ToString());
+
+            programIsChangingStuff = false;
+        }
+
+        private void textBoxTextureName_TextChanged(object sender, EventArgs e)
+        {
+            if (programIsChangingStuff)
+                return;
+
+            if (listBoxPatterns.SelectedItem != null)
+            {
+                programIsChangingStuff = true;
+                patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex).TextureName = textBoxTextureName.Text;
+                listBoxPatterns.Items[listBoxPatterns.SelectedIndex] = patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex).ToString();
+                UnsavedChanges = true;
+                programIsChangingStuff = false;
+            }
+        }
+
+        private void textBoxAnimationName_TextChanged(object sender, EventArgs e)
+        {
+            if (programIsChangingStuff)
+                return;
+
+            if (listBoxPatterns.SelectedItem != null)
+            {
+                patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex).AnimationName = textBoxAnimationName.Text;
+                UnsavedChanges = true;
+            }
+        }
+
+        private void numericFrameCount_ValueChanged(object sender, EventArgs e)
+        {
+            if (programIsChangingStuff)
+                return;
+
+            if (listBoxPatterns.SelectedItem != null)
+            {
+                programIsChangingStuff = true;
+                patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex).FrameCount = (uint)numericFrameCount.Value;
+                listBoxPatterns.Items[listBoxPatterns.SelectedIndex] = patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex).ToString();
+                UnsavedChanges = true;
+                programIsChangingStuff = false;
+            }
+        }
+
+        private void listBoxFrames_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            if (programIsChangingStuff | listBoxPatterns.SelectedItem == null | listBoxFrames.SelectedItem == null)
+                return;
+
+            if (listBoxFrames.SelectedItem != null)
+            {
+                programIsChangingStuff = true;
+
+                ShadowPatternEntry p = patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex);
+                ShadowTexturePatternFrame f = p.frames[listBoxFrames.SelectedIndex];
+
+                numericFrameOffset.Value = f.FrameOffset;
+                numericTextureNumber.Value = f.TextureNumber;
+
+                programIsChangingStuff = false;
+            }
+        }
+
+        private void buttonAddFrame_Click(object sender, EventArgs e)
+        {
+            if (listBoxPatterns.SelectedItem != null)
+            {
+                ShadowTexturePatternFrame f = new ShadowTexturePatternFrame();
+                ShadowPatternEntry p = patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex);
+                p.frames.Add(f);
+                listBoxFrames.Items.Add(f.ToString());
+                UnsavedChanges = true;
+            }
+        }
+
+        private void buttonRemoveFrame_Click(object sender, EventArgs e)
+        {
+            if (listBoxPatterns.SelectedItem != null)
+            {
+                if (listBoxFrames.SelectedItem != null)
+                {
+                    ShadowPatternEntry p = patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex);
+                    int index = listBoxFrames.SelectedIndex;
+                    p.frames.RemoveAt(index);
+                    listBoxFrames.Items.RemoveAt(index);
+                    UnsavedChanges = true;
+                }
+            }
+        }
+
+        private void numericFrameOffset_ValueChanged(object sender, EventArgs e)
+        {
+            if (programIsChangingStuff)
+                return;
+
+            if (listBoxPatterns.SelectedItem != null)
+                if (listBoxFrames.SelectedItem != null)
+                {
+                    ShadowPatternEntry p = patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex);
+
+                    ShadowTexturePatternFrame f = p.frames[listBoxFrames.SelectedIndex];
+                    f.FrameOffset = (ushort)numericFrameOffset.Value;
+                    p.frames[listBoxFrames.SelectedIndex] = f;
+
+                    programIsChangingStuff = true;
+                    listBoxFrames.Items[listBoxFrames.SelectedIndex] = f.ToString();
+                    programIsChangingStuff = false;
+                    UnsavedChanges = true;
+                }
+        }
+
+        private void numericTextureNumber_ValueChanged(object sender, EventArgs e)
+        {
+            if (programIsChangingStuff)
+                return;
+
+            if (listBoxPatterns.SelectedItem != null)
+                if (listBoxFrames.SelectedItem != null)
+                {
+                    ShadowPatternEntry p = patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex);
+
+                    ShadowTexturePatternFrame f = p.frames[listBoxFrames.SelectedIndex];
+                    f.TextureNumber = (ushort)numericTextureNumber.Value;
+                    p.frames[listBoxFrames.SelectedIndex] = f;
+
+                    programIsChangingStuff = true;
+                    listBoxFrames.Items[listBoxFrames.SelectedIndex] = f.ToString();
+                    programIsChangingStuff = false;
+                    UnsavedChanges = true;
+                }
+        }
+
+        public void Animate()
+        {
+            if (Play)
+                patternSystem.Animate(this);
+        }
+
+        private bool Play = false;
+
+        private void buttonPlay_Click(object sender, EventArgs e)
+        {
+            Play = !Play;
+            if (Play)
+            {
+                buttonPlay.Text = "Stop";
+            }
+            else
+            {
+                buttonPlay.Text = "Play";
+                patternSystem.StopAnimation();
+                labelFrame.Text = "Stopped";
+            }
+        }
+
+        public void SendPlaying(uint counter)
+        {
+            labelFrame.Text = "Frame: " + counter.ToString();
+        }
+
+        private void ShadowTexturePatternEditor_Load(object sender, EventArgs e)
+        {
+            if (HPPConfig.GetInstance().LegacyWindowPriorityBehavior)
+                TopMost = true;
+            else
+                TopMost = false;
+        }
+
+        private void listBoxPatterns_DoubleClick(object sender, EventArgs e)
+        {
+            if (programIsChangingStuff)
+                return;
+
+            if (listBoxPatterns.SelectedItem == null)
+                return;
+
+            ShadowPatternEntry p = patternSystem.GetPatternAt(listBoxPatterns.SelectedIndex);
+
+            string newName = EditBSPName.GetName(p.FileName);
+            p.FileName = newName;
+            listBoxPatterns.Items[listBoxPatterns.SelectedIndex] = p;
+
+            UnsavedChanges = true;
+        }
+    }
+}

--- a/HeroesPowerPlant/ShadowTexturePatternEditor/ShadowTexturePatternEditor.resx
+++ b/HeroesPowerPlant/ShadowTexturePatternEditor/ShadowTexturePatternEditor.resx
@@ -117,4 +117,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <metadata name="menuStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="statusStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>132, 17</value>
+  </metadata>
 </root>

--- a/HeroesPowerPlant/SharpDX/SharpRenderer.cs
+++ b/HeroesPowerPlant/SharpDX/SharpRenderer.cs
@@ -4,7 +4,6 @@ using SharpDX.Direct3D11;
 using SharpDX.DXGI;
 using SharpDX.Windows;
 using System.Collections.Generic;
-using System.IO;
 using System.Windows.Forms;
 using static HeroesPowerPlant.LevelEditor.BSP_IO_Shared;
 
@@ -349,6 +348,7 @@ namespace HeroesPowerPlant
                 frustum = new BoundingFrustum(viewProjection);
 
                 mainForm.TexturePatternEditor.Animate();
+                mainForm.ShadowTexturePatternEditor.Animate();
 
                 if (ShowCollision)
                 {


### PR DESCRIPTION
Resolves #62

Automatic load of *.ADB files within _dat.one
Does not support any ADBs within GDTs (yet).

Fully working and tested read/write support with 1:1 outputs. Tested with additional frames, and with removed frames, and new animations entirely.

Additionally renamed BSP Rename to just "Rename" and reused it for double clicking ADB names in the new Shadow Texture Pattern Editor.

There is a HPP render bug if you leave an ADB animation playing when you change levels. It will 'stutter' and flash black. Avoid this by stopping the animation before switching levels.

Demo video
https://youtu.be/TOQI3JPHt2E 