### PR TITLE
Accurately Render Mad Matrix Splines (Inverse)

### DIFF
--- a/HeroesPowerPlant/ShadowSplineEditor/ShadowSpline.cs
+++ b/HeroesPowerPlant/ShadowSplineEditor/ShadowSpline.cs
@@ -53,7 +53,9 @@ namespace HeroesPowerPlant.ShadowSplineEditor
         {
             List<Vector3> vertices = new List<Vector3>(Vertices.Length);
             foreach (ShadowSplineVertex v in Vertices)
+            {
                 vertices.Add(v.Position);
+            }
 
             CreateMesh(renderer, vertices.ToArray());
         }


### PR DESCRIPTION
* Only the original (real data) spline is editable and highlightable. When editing the real spline, the inverse will also update
* Only applies to Mad Matrix (stg0403) because the game has a hardcoded copy & invert function that runs only for that stage to achieve this.
* Add missing dispose on remove all (explains some weird spline rendering issues)

<img width="1294" height="1198" alt="image" src="https://github.com/user-attachments/assets/3f9b40be-7354-4fd1-86f9-4c4d25cfe597" />


Resolves https://github.com/igorseabra4/HeroesPowerPlant/issues/73