### PR TITLE
Add experimental ShadowTXD library - new Option to toggle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "Submodules/Heroes.SDK"]
 	path = Submodules/Heroes.SDK
 	url = https://github.com/Heroes-Hacking-Central/Heroes.SDK.git
+[submodule "Submodules/ShadowTXD"]
+	path = Submodules/ShadowTXD
+	url = https://github.com/ShadowTheHedgehogHacking/ShadowTXD.git

--- a/HeroesPowerPlant.sln
+++ b/HeroesPowerPlant.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.1.32421.90
+# Visual Studio Version 18
+VisualStudioVersion = 18.4.11626.88 stable
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "HeroesPowerPlant", "HeroesPowerPlant\HeroesPowerPlant.csproj", "{A3F86B0F-4A7B-4C01-9A18-79C4EC9A6A05}"
 EndProject
@@ -17,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RenderWareFile", "Submodules\RenderWareFile\RenderWareFile\RenderWareFile.csproj", "{005F2D00-06DE-4EF9-BFEE-80EFAC49E114}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ShadowTXD", "Submodules\ShadowTXD\ShadowTXD.csproj", "{81F8D1DE-643F-2672-E652-DE4F4BC06579}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -76,6 +78,18 @@ Global
 		{005F2D00-06DE-4EF9-BFEE-80EFAC49E114}.Release|x64.Build.0 = Release|Any CPU
 		{005F2D00-06DE-4EF9-BFEE-80EFAC49E114}.Release|x86.ActiveCfg = Release|Any CPU
 		{005F2D00-06DE-4EF9-BFEE-80EFAC49E114}.Release|x86.Build.0 = Release|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Debug|x64.Build.0 = Debug|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Debug|x86.Build.0 = Debug|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Release|Any CPU.Build.0 = Release|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Release|x64.ActiveCfg = Release|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Release|x64.Build.0 = Release|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Release|x86.ActiveCfg = Release|Any CPU
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -84,6 +98,7 @@ Global
 		{3188228B-3DC5-4E68-BBCA-23E990038B39} = {39B59C2E-28E6-4DA7-B3C7-D788DBEA69FC}
 		{D0DF4600-8E65-47E7-8C4F-193FD0083ACB} = {39B59C2E-28E6-4DA7-B3C7-D788DBEA69FC}
 		{005F2D00-06DE-4EF9-BFEE-80EFAC49E114} = {39B59C2E-28E6-4DA7-B3C7-D788DBEA69FC}
+		{81F8D1DE-643F-2672-E652-DE4F4BC06579} = {39B59C2E-28E6-4DA7-B3C7-D788DBEA69FC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {1367AC93-CFC8-458F-95DB-1999C8F0DB6A}

--- a/HeroesPowerPlant/HeroesPowerPlant.csproj
+++ b/HeroesPowerPlant/HeroesPowerPlant.csproj
@@ -374,6 +374,7 @@
     <ProjectReference Include="..\Submodules\Heroes.SDK\Heroes.SDK.Library\Heroes.SDK.csproj" />
     <ProjectReference Include="..\Submodules\HeroesPowerPlant.RemoteControl.ReloadedII\HeroesPowerPlant.RemoteControl.Shared\HeroesPowerPlant.RemoteControl.Shared.csproj" />
     <ProjectReference Include="..\Submodules\RenderWareFile\RenderWareFile\RenderWareFile.csproj" />
+    <ProjectReference Include="..\Submodules\ShadowTXD\ShadowTXD.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="AFSLib" Version="1.1.2" />

--- a/HeroesPowerPlant/MainForm/MainForm.Designer.cs
+++ b/HeroesPowerPlant/MainForm/MainForm.Designer.cs
@@ -93,6 +93,7 @@ namespace HeroesPowerPlant.MainForm
             disableRendering_ToolStripMenuItem = new ToolStripMenuItem();
             LimitFPS_ToolStripMenuItem = new ToolStripMenuItem();
             LegacyWindowPriorityBehavior_ToolStripMenuItem = new ToolStripMenuItem();
+            UseShadowTXDForTextures_ToolStripMenuItem = new ToolStripMenuItem();
             statusStrip1 = new StatusStrip();
             toolStripStatusLabel1 = new ToolStripStatusLabel();
             renderPanel = new Panel();
@@ -333,7 +334,7 @@ namespace HeroesPowerPlant.MainForm
             // 
             // optionsToolStripMenuItem
             // 
-            optionsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { noCullingCToolStripMenuItem, wireframeFToolStripMenuItem, colorsToolStripMenuItem, toolStripSeparator3, mouseModeToolStripMenuItem, startPosToolStripMenuItem, splinesToolStripMenuItem, renderByChunkToolStripMenuItem, chunkBoxesToolStripMenuItem, showCollisionXToolStripMenuItem, showQuadtreeTToolStripMenuItem, showObjectsGToolStripMenuItem, camerasVToolStripMenuItem, toolStripSeparator4, checkForUpdatesOnStartupToolStripMenuItem, checkForUpdatesNowToolStripMenuItem, vSyncToolStripMenuItem, autoLoadLastProjectOnLaunchToolStripMenuItem, autoSaveProjectOnClosingToolStripMenuItem, cameraViewSettingsToolStripMenuItem, disableRendering_ToolStripMenuItem, LimitFPS_ToolStripMenuItem, LegacyWindowPriorityBehavior_ToolStripMenuItem });
+            optionsToolStripMenuItem.DropDownItems.AddRange(new ToolStripItem[] { noCullingCToolStripMenuItem, wireframeFToolStripMenuItem, colorsToolStripMenuItem, toolStripSeparator3, mouseModeToolStripMenuItem, startPosToolStripMenuItem, splinesToolStripMenuItem, renderByChunkToolStripMenuItem, chunkBoxesToolStripMenuItem, showCollisionXToolStripMenuItem, showQuadtreeTToolStripMenuItem, showObjectsGToolStripMenuItem, camerasVToolStripMenuItem, toolStripSeparator4, checkForUpdatesOnStartupToolStripMenuItem, checkForUpdatesNowToolStripMenuItem, vSyncToolStripMenuItem, autoLoadLastProjectOnLaunchToolStripMenuItem, autoSaveProjectOnClosingToolStripMenuItem, cameraViewSettingsToolStripMenuItem, disableRendering_ToolStripMenuItem, LimitFPS_ToolStripMenuItem, LegacyWindowPriorityBehavior_ToolStripMenuItem, UseShadowTXDForTextures_ToolStripMenuItem });
             optionsToolStripMenuItem.Name = "optionsToolStripMenuItem";
             optionsToolStripMenuItem.Size = new System.Drawing.Size(92, 29);
             optionsToolStripMenuItem.Text = "Options";
@@ -546,6 +547,13 @@ namespace HeroesPowerPlant.MainForm
             LegacyWindowPriorityBehavior_ToolStripMenuItem.Text = "Legacy Window Priority Behavior";
             LegacyWindowPriorityBehavior_ToolStripMenuItem.Click += LegacyWindowPriorityBehavior_ToolStripMenuItem_Click;
             // 
+            // UseShadowTXDForTextures_ToolStripMenuItem
+            // 
+            UseShadowTXDForTextures_ToolStripMenuItem.Name = "UseShadowTXDForTextures_ToolStripMenuItem";
+            UseShadowTXDForTextures_ToolStripMenuItem.Size = new System.Drawing.Size(380, 34);
+            UseShadowTXDForTextures_ToolStripMenuItem.Text = "Use ShadowTXD for Textures";
+            UseShadowTXDForTextures_ToolStripMenuItem.Click += UseShadowTXDForTextures_ToolStripMenuItem_Click;
+            // 
             // statusStrip1
             // 
             statusStrip1.ImageScalingSize = new System.Drawing.Size(20, 20);
@@ -670,6 +678,7 @@ namespace HeroesPowerPlant.MainForm
         private ToolStripMenuItem LimitFPS_ToolStripMenuItem;
         private ToolStripMenuItem shadowLayoutMiscToolsToolStripMenuItem;
         private ToolStripMenuItem LegacyWindowPriorityBehavior_ToolStripMenuItem;
+        private ToolStripMenuItem UseShadowTXDForTextures_ToolStripMenuItem;
         private ToolStripMenuItem ResourceToolStripMenuItemSetAFS;
         private ToolStripMenuItem ResourceToolStripMenuItemSetFNT;
         private ToolStripMenuItem openHeroesLevelToolStripMenuItem;

--- a/HeroesPowerPlant/MainForm/MainForm.cs
+++ b/HeroesPowerPlant/MainForm/MainForm.cs
@@ -1353,6 +1353,11 @@ namespace HeroesPowerPlant.MainForm
             LegacyWindowPriorityBehavior_ToolStripMenuItem.Checked = isEnabled;
         }
 
+        public void SetUseShadowTXDForTextures(bool isEnabled)
+        {
+            UseShadowTXDForTextures_ToolStripMenuItem.Checked = isEnabled;
+        }
+
         public void SetMaxFPS()
         {
             if (LimitFPS_ToolStripMenuItem.Checked)
@@ -1381,6 +1386,12 @@ namespace HeroesPowerPlant.MainForm
                 LegacyWindowPriorityBehavior_ToolStripMenuItem.Checked = false;
             HPPConfig.GetInstance().LegacyWindowPriorityBehavior = LegacyWindowPriorityBehavior_ToolStripMenuItem.Checked;
             SetAllTopMost(true); // invoke reset
+        }
+
+        private void UseShadowTXDForTextures_ToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            UseShadowTXDForTextures_ToolStripMenuItem.Checked = !UseShadowTXDForTextures_ToolStripMenuItem.Checked;
+            HPPConfig.GetInstance().UseShadowTXDForTextures = UseShadowTXDForTextures_ToolStripMenuItem.Checked;
         }
 
         private void ResourceToolStripMenuItemSetAFS_Click(object sender, EventArgs e)

--- a/HeroesPowerPlant/Shared/IO/Config/HPPConfig.cs
+++ b/HeroesPowerPlant/Shared/IO/Config/HPPConfig.cs
@@ -23,6 +23,7 @@ namespace HeroesPowerPlant.Shared.IO.Config
         public bool VSync { get; set; } = true;
         public bool LimitFPS { get; set; } = true;
         public bool LegacyWindowPriorityBehavior { get; set; } = false;
+        public bool UseShadowTXDForTextures { get; set; } = false;
 
         public decimal LimitFPSValue { get; set; } = 60.0000m;
 
@@ -100,6 +101,7 @@ namespace HeroesPowerPlant.Shared.IO.Config
 
                 mainForm.SetLimitFPS(LimitFPS, LimitFPSValue);
                 mainForm.SetWindowPriorityBehavior(LegacyWindowPriorityBehavior);
+                mainForm.SetUseShadowTXDForTextures(UseShadowTXDForTextures);
 
                 mainForm.SetCheckForUpdatesOnStartup(CheckForUpdatesOnStartup);
                 mainForm.SetAutoLoadLastProject(AutomaticallyLoadLastConfig);

--- a/HeroesPowerPlant/SharpDX/TextureManager.cs
+++ b/HeroesPowerPlant/SharpDX/TextureManager.cs
@@ -1,7 +1,9 @@
-﻿using HeroesONE_R.Structures;
+using HeroesONE_R.Structures;
 using HeroesONE_R.Structures.Subsctructures;
+using HeroesPowerPlant.Shared.IO.Config;
 using RenderWareFile;
 using RenderWareFile.Sections;
+using ShadowTXD;
 using SharpDX.Direct3D11;
 using System;
 using System.Collections.Generic;
@@ -189,6 +191,12 @@ namespace HeroesPowerPlant
 
         public static void SetupTextureDisplay(byte[] txdFile, SharpRenderer renderer, BSPRenderer bspRenderer)
         {
+            if (HPPConfig.GetInstance().UseShadowTXDForTextures)
+            {
+                SetupTextureDisplayUsingShadowTXD(txdFile, renderer, bspRenderer);
+                return;
+            }
+
             if (!Directory.Exists(tempGcTxdsDir))
                 Directory.CreateDirectory(tempGcTxdsDir);
             if (!Directory.Exists(tempPcTxdsDir))
@@ -203,6 +211,36 @@ namespace HeroesPowerPlant
 
             File.Delete(pathToGcTXD);
             File.Delete(pathToPcTXD);
+        }
+
+        private static void SetupTextureDisplayUsingShadowTXD(byte[] txdData, SharpRenderer renderer, BSPRenderer bspRenderer)
+        {
+            var textures = TxdFile.ExtractTextures(new MemoryStream(txdData));
+
+            string tempDir = Path.Combine(Path.GetTempPath(), "HPP_ShadowTXD");
+            if (!Directory.Exists(tempDir))
+                Directory.CreateDirectory(tempDir);
+
+            try
+            {
+                foreach (var texture in textures)
+                {
+                    string pngPath = Path.Combine(tempDir, texture.Name + ".png");
+                    PngWriter.Write(texture.RgbaData, texture.Width, texture.Height, pngPath);
+                    AddTexturePNG(pngPath, renderer);
+                }
+
+                ReapplyTextures(renderer, bspRenderer);
+            }
+            finally
+            {
+                foreach (var texture in textures)
+                {
+                    string pngPath = Path.Combine(tempDir, texture.Name + ".png");
+                    if (File.Exists(pngPath))
+                        File.Delete(pngPath);
+                }
+            }
         }
 
         private static void PerformTXDConversionExternal(bool toPC = true, bool compress = false, bool generateMipmaps = false)


### PR DESCRIPTION
Adds a new toggle "Use ShadowTXD for Textures"

<img width="573" height="670" alt="image" src="https://github.com/user-attachments/assets/0a8e3bb9-d97c-4a11-8e67-d4332aa4cafe" />

This is an experimental library that handles reading TXDs from GC/Xbox (it will break for PS2).
It is off by default until it is more stable.

Use it to fix the https://github.com/igorseabra4/HeroesPowerPlant/issues/76, but understand the caveat there may be other wrong render or other issues with it.

Some issues identified so far is 'black/broken' renders will not show, and some rolling textures like the prison island river are applied wrong.

Existing:
<img width="834" height="620" alt="image" src="https://github.com/user-attachments/assets/c738f811-30f8-4f49-a602-9d6555c9c2b6" />

New:
<img width="979" height="690" alt="image" src="https://github.com/user-attachments/assets/efcb9e6a-f84c-42db-9cc1-415701acc89b" />
<img width="1769" height="503" alt="image" src="https://github.com/user-attachments/assets/20a4f136-7ed3-4a99-9a6b-10947d9557d2" />
